### PR TITLE
Keycloak ha postgres

### DIFF
--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak-postgres:1.2.0.Beta1
+FROM jboss/keycloak-postgres:1.2.0.CR1
 
 ADD update-standalone-ha.xsl /opt/jboss/keycloak/
 RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/update-standalone-ha.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/update-standalone-ha.xsl

--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,11 +1,4 @@
-FROM jboss/base-jdk:7
-
-ENV KEYCLOAK_VERSION 1.2.0.Beta1
-
-RUN cd $HOME; curl -O http://central.maven.org/maven2/org/keycloak/keycloak-appliance-dist-all/$KEYCLOAK_VERSION/keycloak-appliance-dist-all-$KEYCLOAK_VERSION.zip; unzip keycloak-appliance-dist-all-$KEYCLOAK_VERSION.zip; mv $HOME/keycloak-appliance-dist-all-$KEYCLOAK_VERSION/keycloak $HOME/keycloak; rm -rf $HOME/keycloak-appliance-dist-all-$KEYCLOAK_VERSION.zip; rm -rf $HOME/keycloak-appliance-dist-all-$KEYCLOAK_VERSION
-
-RUN mkdir -p /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main; cd /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main; curl -O http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1102-jdbc3/postgresql-9.3-1102-jdbc3.jar
-ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main/
+FROM jboss/keycloak-postgres:1.2.0.Beta1
 
 ADD update-standalone-ha.xsl /opt/jboss/keycloak/
 RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/update-standalone-ha.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/update-standalone-ha.xsl
@@ -16,9 +9,5 @@ ADD start.sh /opt/jboss/keycloak/bin/
 USER root
 RUN chmod 755 /opt/jboss/keycloak/bin/start.sh; chown jboss:jboss /opt/jboss/keycloak/bin/start.sh
 USER jboss
-
-ENV JBOSS_HOME /opt/jboss/keycloak
-
-EXPOSE 8080
 
 CMD ["/opt/jboss/keycloak/bin/start.sh"]

--- a/server-ha-postgres/update-standalone-ha.xsl
+++ b/server-ha-postgres/update-standalone-ha.xsl
@@ -7,34 +7,6 @@
 
     <xsl:output method="xml" indent="yes"/>
 
-    <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
-        <datasource jndi-name="java:jboss/datasources/KeycloakDS" enabled="true" use-java-context="true" pool-name="KeycloakDS" use-ccm="true">
-            <connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</connection-url>
-            <driver>postgresql</driver>
-            <security>
-                <user-name>${env.POSTGRES_USERNAME:keycloak}</user-name>
-                <password>${env.POSTGRES_PASSWORD:password}</password>
-            </security>
-            <validation>
-                <check-valid-connection-sql>SELECT 1</check-valid-connection-sql>
-                <background-validation>true</background-validation>
-                <background-validation-millis>60000</background-validation-millis>
-            </validation>
-            <pool>
-                <flush-strategy>IdleConnections</flush-strategy>
-            </pool>
-        </datasource>
-    </xsl:template>
-
-    <xsl:template match="//ds:subsystem/ds:datasources/ds:drivers">
-        <xsl:copy>
-            <xsl:apply-templates select="node()|@*"/>
-                <driver name="postgresql" module="org.postgresql.jdbc">
-                    <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
-                </driver>
-        </xsl:copy>
-    </xsl:template>
-
     <xsl:template match="//ispn:subsystem">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>

--- a/server-mysql/Dockerfile
+++ b/server-mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:1.2.0.Beta1
+FROM jboss/keycloak:1.2.0.CR1
 
 ADD changeDatabase.xsl /opt/jboss/keycloak/
 RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml; java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/changeDatabase.xsl

--- a/server-mysql/Dockerfile
+++ b/server-mysql/Dockerfile
@@ -1,6 +1,6 @@
 FROM jboss/keycloak:1.2.0.Beta1
 
 ADD changeDatabase.xsl /opt/jboss/keycloak/
-RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml
+RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml; java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/changeDatabase.xsl
 RUN mkdir -p /opt/jboss/keycloak/modules/system/layers/base/com/mysql/jdbc/main; cd /opt/jboss/keycloak/modules/system/layers/base/com/mysql/jdbc/main && curl -O http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.18/mysql-connector-java-5.1.18.jar
 ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/com/mysql/jdbc/main/

--- a/server-postgres/Dockerfile
+++ b/server-postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM jboss/keycloak:1.2.0.Beta1
 
 ADD changeDatabase.xsl /opt/jboss/keycloak/
-RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml
+RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml; java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/changeDatabase.xsl
 RUN mkdir -p /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main; cd /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main; curl -O http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1102-jdbc3/postgresql-9.3-1102-jdbc3.jar
 ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main/

--- a/server-postgres/Dockerfile
+++ b/server-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:1.2.0.Beta1
+FROM jboss/keycloak:1.2.0.CR1
 
 ADD changeDatabase.xsl /opt/jboss/keycloak/
 RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml; java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/changeDatabase.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/changeDatabase.xsl

--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -8,7 +8,7 @@
 
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
         <ds:datasource jndi-name="java:jboss/datasources/KeycloakDS" enabled="true" use-java-context="true" pool-name="KeycloakDS" use-ccm="true">
-            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
+            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
             <ds:driver>postgresql</ds:driver>
             <ds:security>
               <ds:user-name>${env.POSTGRES_USERNAME:keycloak}</ds:user-name>


### PR DESCRIPTION
- Fixed parent hierarchy for keycloak-ha-postgres, and incremented to next version 1.2.0.CR1
- Added config update of standalone-ha.xml in keycloak-postgres, and keycloak-mysql
Note: jboss/keycloak:1.2.0.CR1 has to be released first for the changed Dockerfiles to build.