### PR TITLE
Add support for CentOS 7 base image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,7 @@ ENV KEYCLOAK_VERSION 1.2.0.Final
 
 USER root
 
-RUN yum install -y jq && yum clean all
+RUN yum install -y epel-release && yum install -y jq && yum clean all
 
 USER jboss
 


### PR DESCRIPTION
jboss/base uses CentOS 7 as of Jul 1, 2015. Fix keycloak image to support CentOS 7.

Currently, docker build fails because it cannot find the jq package. This pull request fixes by adding `epel-release` before installing `jq`.

```
$ docker build --no-cache server
Sending build context to Docker daemon 5.632 kB
Sending build context to Docker daemon 
Step 0 : FROM jboss/base-jdk:7
 ---> 6adb355a1864
Step 1 : ENV KEYCLOAK_VERSION 1.2.0.Final
 ---> Running in 2b468477bb51
 ---> e536d3fea6bf
Removing intermediate container 2b468477bb51
Step 2 : USER root
 ---> Running in 0c8f5acd67fa
 ---> abfd759fd030
Removing intermediate container 0c8f5acd67fa
Step 3 : RUN yum install -y jq && yum clean all
 ---> Running in d13413232015
Loaded plugins: fastestmirror
Determining fastest mirrors
 * base: mirror.atlanticmetro.net
 * extras: mirrors.rit.edu
 * updates: mirror.atlanticmetro.net
No package jq available.
Error: Nothing to do
The command '/bin/sh -c yum install -y jq && yum clean all' returned a non-zero code: 1
```