### PR TITLE
Fix POSTGRES_USER bug that doesn't fit the API in README.md

### DIFF
--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -11,7 +11,7 @@
             <ds:connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
             <ds:driver>postgresql</ds:driver>
             <ds:security>
-              <ds:user-name>${env.POSTGRES_USERNAME:keycloak}</ds:user-name>
+              <ds:user-name>${env.POSTGRES_USER:keycloak}</ds:user-name>
               <ds:password>${env.POSTGRES_PASSWORD:password}</ds:password>
             </ds:security>
             <ds:validation>


### PR DESCRIPTION
The POSTGRES_USER variable changed to POSTGRES_USERNAME, and this is breaking the API in README.md.

This is causing breaks in automated updates in production environments, that expects to use POSTGRES_USER, the default variable from postgres container.