### PR TITLE
Fix to datasources namespace (v2.0 -> v3.0)

### DIFF
--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ds="urn:jboss:domain:datasources:2.0">
+                xmlns:ds="urn:jboss:domain:datasources:3.0">
 
     <xsl:output method="xml" indent="yes"/>
 


### PR DESCRIPTION
It seems that the stylesheet to update the standalon(-ha).xml references to datasources namespace with version 2.0 but it actually is 3.0 at least with Keycloak v1.3.1.Final.