### PR TITLE
Exposing needed port in documentation

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -6,7 +6,7 @@ Example Dockerfile with Keycloak server.
 
 To boot in standalone mode
 
-    docker run jboss/keycloak
+    docker run -p 8080:8080 jboss/keycloak
 
 Once it boots, you can login to the admin console using admin/admin for the first login.
 


### PR DESCRIPTION
It happened to me and other coworkers more than once: run the image and forget that since port 8080 is not exposed, it gets impossible to access it.