### PR TITLE
Xml namespace for datasource changed

### DIFF
--- a/server-mysql/changeDatabase.xsl
+++ b/server-mysql/changeDatabase.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ds="urn:jboss:domain:datasources:2.0">
+                xmlns:ds="urn:jboss:domain:datasources:3.0">
 
     <xsl:output method="xml" indent="yes"/>
 


### PR DESCRIPTION
The xml namespace for datasources was changed from 'urn:jboss:domain:datasources:2.0' to 'urn:jboss:domain:datasources:3.0' with wildfly 9. This change was not considered in the xml transformation file so that the H2 datasource was not changed to the mysql one.