### PR TITLE
Add userSessionPersister configuration to allow the server to start.

### DIFF
--- a/server-ha-postgres/keycloak-server.json
+++ b/server-ha-postgres/keycloak-server.json
@@ -26,6 +26,10 @@
         "provider" : "infinispan"
     },
 
+    "userSessionPersister": {
+        "provider" : "jpa"
+    },
+
     "realmCache": {
         "provider": "infinispan"
     },


### PR DESCRIPTION
Following the "Running Keycloak cluster with Docker" post (http://blog.keycloak.org/2015/04/running-keycloak-cluster-with-docker.html) I was unable to get the server to start, receiving a NullPointerException at org.keycloak.models.sessions.infinispan.initializer.OfflineUserSessionLoader.init(OfflineUserSessionLoader.java:25). This was also noticed by one of the commenters on the post.

Looking at the code, it seems as though a UserSessionPersister was coming back null.

I have added to keycloak-server.json the following:

    "userSessionPersister": {
        "provider" : "jpa"
    },

which seems to fix the problem.