### PR TITLE
mysql ssl environment options

### DIFF
--- a/server-mysql/changeDatabase.xsl
+++ b/server-mysql/changeDatabase.xsl
@@ -8,7 +8,7 @@
 
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
         <ds:datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true" use-ccm="true">
-            <ds:connection-url>jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}/${env.MYSQL_DATABASE:keycloak}</ds:connection-url>
+            <ds:connection-url>jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}/${env.MYSQL_DATABASE:keycloak}?useSSL=${env.MYSQL_SSL:false}&amp;requireSSL=${env.MYSQL_SSL:false}&amp;verifyServerCertificate=${env.MYSQL_SSL_VERIFY:false}</ds:connection-url>
             <ds:driver>mysql</ds:driver>
             <ds:security>
                 <ds:user-name>${env.MYSQL_USERNAME:keycloak}</ds:user-name>


### PR DESCRIPTION
- adding the environment variables MYSQL_SSL and MYSQL_SSL_VERIFY as a means to enforce SSL and verification requirement of cert