### PR TITLE
Use docker-compose instead of docker container linking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is a set of Docker images related to Keycloak.
 - [keycloak](https://registry.hub.docker.com/u/jboss/keycloak/) example Keycloak server
 - [keycloak-mysql](https://registry.hub.docker.com/u/jboss/keycloak-mysql/) example connecting Keycloak to MySQL
 - [keycloak-postgres](https://registry.hub.docker.com/u/jboss/keycloak-postgres/) example connecting Keycloak to PostgreSQL
+- [keycloak-mongo](https://registry.hub.docker.com/u/jboss/keycloak-mongo/) example connecting Keycloak to MongoDB
 - [keycloak-adapter-wildfly](https://registry.hub.docker.com/u/jboss/keycloak-adapter-wildfly/) builds on top of the [jboss/wildfly](https://registry.hub.docker.com/u/jboss/wildfly/) image, adding the Keycloak adapter for Wildfly to it, as well as the required changes to the standalone.xml
 - [keycloak-examples](https://registry.hub.docker.com/u/jboss/keycloak-examples/) builds on top of [keycloak](https://registry.hub.docker.com/u/jboss/keycloak/), adding the examples.
 
+Additionally, this project contains [an example of a Keycloak HA cluster](server-ha-postgres).

--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,3 +1,0 @@
-FROM jboss/keycloak-postgres:latest
-
-CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml"]

--- a/server-ha-postgres/docker-compose.yml
+++ b/server-ha-postgres/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '2'
+services:
+
+  proxy:
+    extends:
+      file: proxy/proxy.yml
+      service: proxy
+    ports:
+      - "8080:80"
+    depends_on:
+      - server_a
+      - server_b
+
+  server_a:
+    extends:
+      file: server/server.yml
+      service: server
+    command: ["-b", "0.0.0.0", "-bprivate", "server_a", "--server-config", "standalone-ha.xml"]
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+    depends_on:
+      - database
+
+  server_b:
+    extends:
+      file: server/server.yml
+      service: server
+    command: ["-b", "0.0.0.0", "-bprivate", "server_b", "--server-config", "standalone-ha.xml"]
+    depends_on:
+      - database
+
+  database:
+    image: postgres
+    environment:
+      POSTGRES_DATABASE: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+      POSTGRES_ROOT_PASSWORD: root_password

--- a/server-ha-postgres/proxy/Dockerfile
+++ b/server-ha-postgres/proxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM haproxy
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/server-ha-postgres/proxy/haproxy.cfg
+++ b/server-ha-postgres/proxy/haproxy.cfg
@@ -1,0 +1,17 @@
+global
+    maxconn 256
+
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend http-in
+    bind *:80
+    default_backend server
+
+backend server
+    balance roundrobin
+    server a server_a:8080 maxconn 32
+    server b server_b:8080 maxconn 32

--- a/server-ha-postgres/proxy/proxy.yml
+++ b/server-ha-postgres/proxy/proxy.yml
@@ -1,0 +1,5 @@
+version: '2'
+services:
+
+  proxy:
+    build: .

--- a/server-ha-postgres/server/server.yml
+++ b/server-ha-postgres/server/server.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+
+  server:
+    image: jboss/keycloak-postgres:latest
+    environment:
+      POSTGRES_HOST: database
+      POSTGRES_PORT: 5432
+      POSTGRES_DATABASE: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak

--- a/server-mongo/README.md
+++ b/server-mongo/README.md
@@ -1,28 +1,47 @@
 # Keycloak MongoDB
 
-Extends the Keycloak docker image to use MongoDB
+This Keycloak image extends the base Keycloak docker image to use MongoDB. To build and properly name this image, run:
+
+```
+docker build -t jboss/keycloak-mongo .
+```
 
 ## Usage
 
-### Start a MongoDB instance
+### Use `docker-compose` to start all services
 
-First start a MongoDB instance using the MongoDB docker image:
+To start both the Keycloak and the MongoDB instances, use `docker-compose`:
 
-    docker run --name mongo -e MONGODB_DBNAME=keycloak -d mongo
+```
+docker-compose up
+```
 
-### Start a Keycloak instance
+[Refer to the documentation on `docker-compose` for more information regarding this tool.](https://docs.docker.com/compose/reference/overview/)
 
-Start a Keycloak instance and connect to the MongoDB instance:
+### Connect to an existing MongoDB instance
 
-    docker run --name keycloak --link mongo:mongo jboss/keycloak-mongo
+To connect to an existing MongoDB instance, use `docker run` and specify the MongoDB connection criteria via environment variables:
+
+```
+docker run --name keycloak -e MONGO_DATABASE=kcdatabase -e MONGO_USER=kcuser jboss/keycloak-mongo
+```
 
 ### Environment variables
 
-When starting the Keycloak instance you can pass a number of environment variables to configure how it connects to MongoDB. For example:
+When starting the container via `docker run` you can pass a number of environment variables to configure the MongoDB connection criteria. For example:
 
-    docker run --name keycloak --link mongo:mongo -e MONGODB_DBNAME=keycloak jboss/keycloak-mongo
+#### MONGO_HOST
 
-#### MONGODB_DBNAME
+Specify the address of the server hosting the MongoDB database (required).
 
-Specify name of MongoDB database (optional, default is `keycloak`).
+#### MONGO_PORT
 
+Specify the port for MongoDB database (optional, default is `27017`).
+
+#### MONGO_DATABASE
+
+Specify the name of MongoDB database (optional, default is `keycloak`).
+
+#### MONGO_USER
+
+Specify the user for MongoDB database (optional, default is `keycloak`).

--- a/server-mongo/changeDatabase.jq
+++ b/server-mongo/changeDatabase.jq
@@ -3,9 +3,9 @@
   .realm.provider = "mongo" | 
   .user.provider = "mongo" |
   .userSessionPersister.provider = "mongo" |  
-  .connectionsMongo.default.host = "${env.MONGO_PORT_27017_TCP_ADDR}" |
-  .connectionsMongo.default.port = "27017" |
-  .connectionsMongo.default.db = "${env.MONGODB_DBNAME:keycloak}" |
+  .connectionsMongo.default.host = "${env.MONGO_HOST}" |
+  .connectionsMongo.default.port = "${env.MONGO_PORT:27017}" |
+  .connectionsMongo.default.db = "${env.MONGO_DATABASE:keycloak}" |
   .connectionsMongo.default.connectionsPerHost = 100 |
   .connectionsMongo.default.databaseSchema = "update" |
   del (.eventsStore.jpa) | 

--- a/server-mongo/docker-compose.yml
+++ b/server-mongo/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+
+  server:
+    build: .
+    image: jboss/keycloak-mongo
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      MONGO_HOST: database
+      MONGO_PORT: 27017
+      MONGO_DATABASE: keycloak
+      MONGO_USER: keycloak
+    depends_on:
+      - database
+
+  database:
+    image: mongo
+    environment:
+      MONGO_DATABASE: keycloak
+      MONGO_USER: keycloak

--- a/server-mysql/README.md
+++ b/server-mysql/README.md
@@ -1,35 +1,51 @@
 # Keycloak MySQL
 
-Extends the Keycloak docker image to use MySQL
+This Keycloak image extends the base Keycloak docker image to use MySQL. To build and properly name this image, run:
+
+```
+docker build -t jboss/keycloak-mysql .
+```
 
 ## Usage
 
-### Start a MySQL instance
+### Use `docker-compose` to start all services
 
-First start a MySQL instance using the MySQL docker image:
+To start both the Keycloak and the MySQL instances, use `docker-compose`:
 
-    docker run --name mysql -e MYSQL_DATABASE=keycloak -e MYSQL_USER=keycloak -e MYSQL_PASSWORD=password -e MYSQL_ROOT_PASSWORD=root_password -d mysql
+```
+docker-compose up
+```
 
-### Start a Keycloak instance
+[Refer to the documentation on `docker-compose` for more information regarding this tool.](https://docs.docker.com/compose/reference/overview/)
 
-Start a Keycloak instance and connect to the MySQL instance:
+### Connect to an existing MySQL instance
 
-    docker run --name keycloak --link mysql:mysql jboss/keycloak-mysql
+To connect to an existing MySQL instance, use `docker run` and specify the MySQL connection criteria via environment variables:
+
+```
+docker run --name keycloak -e MYSQL_DATABASE=kcdatabase -e MYSQL_USER=kcuser -e MYSQL_PASSWORD=kcpassword jboss/keycloak-mysql
+```
 
 ### Environment variables
 
-When starting the Keycloak instance you can pass a number of environment variables to configure how it connects to MySQL. For example:
+When starting the container via `docker run` you can pass a number of environment variables to configure the MySQL connection criteria. For example:
 
-    docker run --name keycloak --link mysql:mysql -e MYSQL_DATABASE=kcdb -e MYSQL_USER=kcuser -e MYSQL_PASSWORD=kcpassword jboss/keycloak-mysql
+#### MYSQL_HOST
+
+Specify the address of the server hosting the MySQL database (required).
+
+#### MYSQL_PORT
+
+Specify the port for MySQL database (optional, default is `3306`).
 
 #### MYSQL_DATABASE
 
-Specify name of MySQL database (optional, default is `keycloak`).
+Specify the name of MySQL database (optional, default is `keycloak`).
 
 #### MYSQL_USER
 
-Specify user for MySQL database (optional, default is `keycloak`).
+Specify the user for MySQL database (optional, default is `keycloak`).
 
 #### MYSQL_PASSWORD
 
-Specify password for MySQL database (optional, default is `keycloak`).
+Specify the password for MySQL database (optional, default is `keycloak`).

--- a/server-mysql/changeDatabase.xsl
+++ b/server-mysql/changeDatabase.xsl
@@ -8,7 +8,7 @@
 
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
         <ds:datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true" use-ccm="true">
-            <ds:connection-url>jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}/${env.MYSQL_DATABASE:keycloak}</ds:connection-url>
+            <ds:connection-url>jdbc:mysql://${env.MYSQL_HOST}:${env.MYSQL_PORT:3306}/${env.MYSQL_DATABASE:keycloak}</ds:connection-url>
             <ds:driver>mysql</ds:driver>
             <ds:security>
                 <ds:user-name>${env.MYSQL_USERNAME:keycloak}</ds:user-name>

--- a/server-mysql/docker-compose.yml
+++ b/server-mysql/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+
+  server:
+    build: .
+    image: jboss/keycloak-mysql
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      MYSQL_HOST: database
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: keycloak
+    depends_on:
+      - database
+
+  database:
+    image: mysql
+    environment:
+      MYSQL_DATABASE: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: keycloak
+      MYSQL_ROOT_PASSWORD: root_password

--- a/server-postgres/README.md
+++ b/server-postgres/README.md
@@ -1,35 +1,51 @@
 # Keycloak PostgreSQL
 
-Extends the Keycloak docker image to use PostgreSQL
+This Keycloak image extends the base Keycloak docker image to use PostgreSQL. To build and properly name this image, run:
+
+```
+docker build -t jboss/keycloak-postgres .
+```
 
 ## Usage
 
-### Start a PostgreSQL instance
+### Use `docker-compose` to start all services
 
-First start a PostgreSQL instance using the PostgreSQL docker image:
+To start both the Keycloak and the PostgreSQL instances, use `docker-compose`:
 
-    docker run --name postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=root_password -d postgres
+```
+docker-compose up
+```
 
-### Start a Keycloak instance
+[Refer to the documentation on `docker-compose` for more information regarding this tool.](https://docs.docker.com/compose/reference/overview/)
 
-Start a Keycloak instance and connect to the PostgreSQL instance:
+### Connect to an existing PostgreSQL instance
 
-    docker run --name keycloak --link postgres:postgres jboss/keycloak-postgres
+To connect to an existing PostgreSQL instance, use `docker run` and specify the PostgreSQL connection criteria via environment variables:
+
+```
+docker run --name keycloak -e POSTGRES_DATABASE=kcdatabase -e POSTGRES_USER=kcuser -e POSTGRES_PASSWORD=kcpassword jboss/keycloak-postgres
+```
 
 ### Environment variables
 
-When starting the Keycloak instance you can pass a number of environment variables to configure how it connects to PostgreSQL. For example:
+When starting the container via `docker run` you can pass a number of environment variables to configure the PostgreSQL connection criteria. For example:
 
-    docker run --name keycloak --link postgres:postgres -e POSTGRES_DATABASE=kcdatabase -e POSTGRES_USER=kcuser -e POSTGRES_PASSWORD=kcpassword jboss/keycloak-postgres
+#### POSTGRES_HOST
+
+Specify the address of the server hosting the PostgreSQL database (required).
+
+#### POSTGRES_PORT
+
+Specify the port for PostgreSQL database (optional, default is `5432`).
 
 #### POSTGRES_DATABASE
 
-Specify name of PostgreSQL database (optional, default is `keycloak`).
+Specify the name of PostgreSQL database (optional, default is `keycloak`).
 
 #### POSTGRES_USER
 
-Specify user for PostgreSQL database (optional, default is `keycloak`).
+Specify the user for PostgreSQL database (optional, default is `keycloak`).
 
 #### POSTGRES_PASSWORD
 
-Specify password for PostgreSQL database (optional, default is `keycloak`).
+Specify the password for PostgreSQL database (optional, default is `keycloak`).

--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -8,7 +8,7 @@
 
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
         <ds:datasource jndi-name="java:jboss/datasources/KeycloakDS" enabled="true" use-java-context="true" pool-name="KeycloakDS" use-ccm="true">
-            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
+            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_HOST}:${env.POSTGRES_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
             <ds:driver>postgresql</ds:driver>
             <ds:security>
               <ds:user-name>${env.POSTGRES_USER:keycloak}</ds:user-name>

--- a/server-postgres/docker-compose.yml
+++ b/server-postgres/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+
+  server:
+    build: .
+    image: jboss/keycloak-postgres
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      POSTGRES_HOST: database
+      POSTGRES_PORT: 5432
+      POSTGRES_DATABASE: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+    depends_on:
+      - database
+
+  database:
+    image: postgres
+    environment:
+      POSTGRES_DATABASE: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+      POSTGRES_ROOT_PASSWORD: root_password


### PR DESCRIPTION
Hey Keycloak community!

This PR contains updates to attach containers via [docker-compose](https://docs.docker.com/compose/overview/) instead of relying on manual, multi-step docker container linking. Some benefits:

- All configuration for the 'cluster' is in one place.
- One, smaller command to bring up the 'cluster': `docker-compose up`
- The `server-ha-progress` can rely upon the `docker-compose.yml` file for command line modifications, instead of using an extra image or relying on the arguments being manually passed to `docker run`.
- More control over env var naming, rather than relying on the auto-generated env vars (e.g., `POSTGRES_PORT_5432_TCP_PORT`).

I also added an HAproxy instance in front of the Keycloak instances in the `server-ha-progres` subproject.

___IMPORTANT! Until the GA `jboss/keycloak-postgres` Image on Docker Hub is Updated___

Before running the `server-ha-postgres` example, you will need to build the image in `server-postgres` locally to prevent the existing `jboss/keycloak-postgres` from being pulled from Docker Hub:
```
docker build -t jboss/keycloak-postgres server-postgres
```
If the GA image is updated, this will no longer be an issue.

I look forward to your comments!