### PR TITLE
Add exec in bash wrapper scripts so that signals propogate

### DIFF
--- a/examples/docker-entrypoint.sh
+++ b/examples/docker-entrypoint.sh
@@ -4,4 +4,5 @@ if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     /opt/jboss/keycloak-demo/keycloak/bin/add-user-keycloak.sh -u $KEYCLOAK_USER -p $KEYCLOAK_PASSWORD >/dev/null
 fi
 
-/opt/jboss/keycloak-demo/keycloak/bin/standalone.sh $@
+exec /opt/jboss/keycloak-demo/keycloak/bin/standalone.sh $@
+exit $?

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -4,4 +4,5 @@ if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     keycloak/bin/add-user.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
 fi
 
-/opt/jboss/keycloak/bin/standalone.sh $@
+exec /opt/jboss/keycloak/bin/standalone.sh $@
+exit $?


### PR DESCRIPTION
When interactively running the current containers `CTRL+C` does not exit wildfly since the signal is not passed on to the process. Making sure that wildfly is the main process fixes this: http://www.projectatomic.io/docs/docker-image-author-guidance/