### PR TITLE
Example Keycloak runnning behind an SSL reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This is a set of Docker images related to Keycloak.
 - [keycloak-postgres](https://registry.hub.docker.com/u/jboss/keycloak-postgres/) example connecting Keycloak to PostgreSQL
 - [keycloak-adapter-wildfly](https://registry.hub.docker.com/u/jboss/keycloak-adapter-wildfly/) builds on top of the [jboss/wildfly](https://registry.hub.docker.com/u/jboss/wildfly/) image, adding the Keycloak adapter for Wildfly to it, as well as the required changes to the standalone.xml
 - [keycloak-examples](https://registry.hub.docker.com/u/jboss/keycloak-examples/) builds on top of [keycloak](https://registry.hub.docker.com/u/jboss/keycloak/), adding the examples.
-
+- [keycloak-reverse-proxy](https://registry.hub.docker.com/u/jboss/keycloak-reverse-proxy/) example running Keycloak behind a reverse proxy

--- a/server-reverse-proxy/Dockerfile
+++ b/server-reverse-proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM jboss/keycloak:latest
+
+ADD changeProxy.xsl /opt/jboss/keycloak/
+RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/changeProxy.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml; java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml -xsl:/opt/jboss/keycloak/changeProxy.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml; rm /opt/jboss/keycloak/changeProxy.xsl

--- a/server-reverse-proxy/README.md
+++ b/server-reverse-proxy/README.md
@@ -1,0 +1,9 @@
+# Keycloak behind Reverse Proxy
+
+Extends the Keycloak docker image to run behind a reverse proxy with SSL offloading.
+
+## Usage
+
+## Other details
+
+This image extends the [`jboss/keycloak`](https://github.com/jboss-dockerfiles/keycloak) image. Please refer to the README.md for selected images for more info.

--- a/server-reverse-proxy/changeProxy.xsl
+++ b/server-reverse-proxy/changeProxy.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+	<!-- Enable proxy address forwarding -->
+    <xsl:template xmlns="urn:jboss:domain:undertow:3.0" xmlns:ut="urn:jboss:domain:undertow:3.0" match="//ut:subsystem/ut:server/ut:http-listener">
+		<http-listener proxy-address-forwarding="true">
+			<xsl:apply-templates select="@*|node()"/>
+		</http-listener>
+    </xsl:template>
+
+	<!-- Enable SSL on a Reverse Proxy -->
+    <xsl:template xmlns:dm="urn:jboss:domain:4.0" match="//dm:server/dm:socket-binding-group/dm:socket-binding[@name='https']/@port">
+		<xsl:attribute name="port">
+			<xsl:text>${jboss.https.port:443}</xsl:text>
+		</xsl:attribute>
+    </xsl:template>
+
+	<!-- Bind Keycloak to the ROOT context -->
+    <xsl:template xmlns="urn:jboss:domain:undertow:3.0" xmlns:ut="urn:jboss:domain:undertow:3.0" match="//ut:subsystem/ut:server/ut:host">
+		<host default-web-module="keycloak-server.war">
+			<xsl:apply-templates select="@*|node()"/>
+		</host>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Hi,

To be able to run the Keycloak example behind an Nginx reverse proxy with SSL offloading I had to manually make some changes to standalone.xml otherwise HTTPS url's were not rendered correctly.

I put this manual changes to standalone.xml in a separate example folder.
Perhaps it could be incorporated in the main example? I am assuming it does not lead to any conflict.

Regards,

Ton Swieb