### PR TITLE
Refactored POSTGRES environment variables

### DIFF
--- a/server-postgres/README.md
+++ b/server-postgres/README.md
@@ -8,7 +8,7 @@ Extends the Keycloak docker image to use PostgreSQL
 
 First start a PostgreSQL instance using the PostgreSQL docker image:
 
-    docker run --name postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=root_password -d postgres
+    docker run --name postgres -e POSTGRES_DB=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=root_password -d postgres
 
 ### Start a Keycloak instance
 
@@ -20,9 +20,13 @@ Start a Keycloak instance and connect to the PostgreSQL instance:
 
 When starting the Keycloak instance you can pass a number of environment variables to configure how it connects to PostgreSQL. For example:
 
-    docker run --name keycloak --link postgres:postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password jboss/keycloak-postgres
+    docker run --name keycloak --link postgres:postgres -e POSTGRES_DB=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password jboss/keycloak-postgres
 
-#### POSTGRES_DATABASE
+#### POSTGRES_HOST
+
+Specify the host address of the PostgreSQL database (optional, defailt is `postgres` which would be a hosts entry if using --link postgres:postgres)
+
+#### POSTGRES_DB
 
 Specify name of PostgreSQL database (optional, default is `keycloak`).
 

--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -8,7 +8,7 @@
 
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']">
         <ds:datasource jndi-name="java:jboss/datasources/KeycloakDS" enabled="true" use-java-context="true" pool-name="KeycloakDS" use-ccm="true">
-            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_PORT_5432_TCP_ADDR}:${env.POSTGRES_PORT_5432_TCP_PORT:5432}/${env.POSTGRES_DATABASE:keycloak}</ds:connection-url>
+            <ds:connection-url>jdbc:postgresql://${env.POSTGRES_HOST:postgres}:${env.POSTGRES_PORT:5432}/${env.POSTGRES_DB:keycloak}</ds:connection-url>
             <ds:driver>postgresql</ds:driver>
             <ds:security>
               <ds:user-name>${env.POSTGRES_USER:keycloak}</ds:user-name>


### PR DESCRIPTION
The jdbc host address was set to POSTGRES_PORT_5432_TCP_ADDR. Updated it to POSTGRES_HOST and set the default to be the link name in the README (postgres).

The jdbc port was set to use env.POSTGRES_PORT_5432_TCP_PORT when the README specified POSTGRES_PORT as an environment variable.

These issues prevent keycloak from deploying.