### PR TITLE
Set a reasonable JGroups bind default for keycloak-ha-postgres

### DIFF
--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,3 +1,5 @@
 FROM jboss/keycloak-postgres:latest
 
 CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml"]
+
+ADD docker-entrypoint.sh /opt/jboss/

--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -3,3 +3,5 @@ FROM jboss/keycloak-postgres:latest
 CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml"]
 
 ADD docker-entrypoint.sh /opt/jboss/
+
+RUN rm keycloak/standalone/configuration/standalone.xml

--- a/server-ha-postgres/README.md
+++ b/server-ha-postgres/README.md
@@ -20,6 +20,12 @@ Start two or more Keycloak instances that form a cluster and connect to the Post
     docker run --name keycloak2 --link postgres:postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password jboss/keycloak-ha-postgres
     docker logs -f keycloak2
 
+What you should see at the second start is log lines with a `(2)` for cluster view, like
+```
+INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-4) ISPN000094: Received new cluster view for channel web: [285553cc5063|1] (2) [285553cc5063, 676929b52b0a]
+```
+
+At the same time the first container's logs should show a number of `cluster-wide rebalance`.
 
 ## Other details
 

--- a/server-ha-postgres/docker-entrypoint.sh
+++ b/server-ha-postgres/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
+    keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+fi
+
+exec /opt/jboss/keycloak/bin/standalone.sh $@
+exit $?

--- a/server-ha-postgres/docker-entrypoint.sh
+++ b/server-ha-postgres/docker-entrypoint.sh
@@ -4,5 +4,9 @@ if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
 fi
 
+export HOSTNAME_IP=$(hostname -i)
+export HOSTNAME_IP_ALL=$(hostname --all-ip-addresses)
+echo "hostname -i returned: $HOSTNAME_IP, -I returned: $HOSTNAME_IP_ALL"
+
 exec /opt/jboss/keycloak/bin/standalone.sh $@
 exit $?

--- a/server-ha-postgres/docker-entrypoint.sh
+++ b/server-ha-postgres/docker-entrypoint.sh
@@ -8,5 +8,5 @@ export HOSTNAME_IP=$(hostname -i)
 export HOSTNAME_IP_ALL=$(hostname --all-ip-addresses)
 echo "hostname -i returned: $HOSTNAME_IP, -I returned: $HOSTNAME_IP_ALL"
 
-exec /opt/jboss/keycloak/bin/standalone.sh $@
+exec /opt/jboss/keycloak/bin/standalone.sh -Djboss.bind.address.private=$HOSTNAME_IP $@
 exit $?


### PR DESCRIPTION
Unless you read https://keycloak.gitbooks.io/server-installation-and-configuration/content/v/2.3/topics/clustering/troubleshooting.html it is difficult to spot the fact that a ha setup using the `docker run` commands in https://hub.docker.com/r/jboss/keycloak-ha-postgres/ for 2.3.0.Final don't actually produce a running cluster.

To accept non-local cluster connections you have to set `-bprivate` or `-Djboss.bind.address.private`. Unlike the public and management ports, 0.0.0.0 is not a valid value here - see [this mailing list thread](https://sourceforge.net/p/javagroups/mailman/message/35478766/).

[Common wisdom](http://lists.jboss.org/pipermail/keycloak-user/2016-November/008273.html) seems to be to use `hostname -i`, which is non-trivial with docker args only. I therefore suggest that `docker-entrypoint.sh` for the `-ha` image exposes that as env.

With that in place and because the last parameter takes precedence we might just as well add it as argument to `/opt/jboss/keycloak/bin/standalone.sh`. An alternative would be to use `env.HOSTNAME_IP` inside the config file, but that makes overriding difficult.

I've also taken the liberty to rm standalone.xml, this being an image specifically for `-ha`. It's quite easy to forget about `--server-config` when you start adding your own command arguments, which reverts the image back to regular standalone behavior with logs saying "Adding singleton resource"). With the file removed you get `FileNotFoundException: /opt/jboss/keycloak/standalone/configuration/standalone.xml` instead.

Due to the warning "Avoid using this option; use hostname --all-ip-addresses instead." on `-i` in the man page for `hostname` there's an alternative env var `HOSTNAME_IP_ALL` which isn't used, but might be useful for additional args or config file changes.
 
