### PR TITLE
update base image to wildfly10.1.0.Final

### DIFF
--- a/adapter-wildfly/Dockerfile
+++ b/adapter-wildfly/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/wildfly:10.0.0.Final
+FROM jboss/wildfly:10.1.0.Final
 
 ENV KEYCLOAK_VERSION 2.4.0.Final
 


### PR DESCRIPTION
Is it possible to update the base Wildfly image for Keycloak adapter to the version 10.1.0.Final?
