### PR TITLE
Added option to enable modcluster multicast listens on host's ip inst…

### DIFF
--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,5 +1,9 @@
 FROM jboss/keycloak-postgres:latest
 
-RUN sed -i 's/\$@/\$\(eval "echo \$@"\)/' /opt/jboss/docker-entrypoint.sh
+WORKDIR /opt/jboss
+ADD src/NetInfo.java .
 
-CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml", "-Djboss.bind.address.private=$(hostname -i)"]
+RUN sed -i 's/\$@/\$\(eval "echo \$@"\)/' /opt/jboss/docker-entrypoint.sh \
+  && $JAVA_HOME/bin/javac NetInfo.java
+
+CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml", "-Djboss.bind.address.private=$(java NetInfo $KEYCLOAK_HA_MULTICAST_NETS)"]

--- a/server-ha-postgres/Dockerfile
+++ b/server-ha-postgres/Dockerfile
@@ -1,3 +1,5 @@
 FROM jboss/keycloak-postgres:latest
 
-CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml"]
+RUN sed -i 's/\$@/\$\(eval "echo \$@"\)/' /opt/jboss/docker-entrypoint.sh
+
+CMD ["-b", "0.0.0.0", "--server-config", "standalone-ha.xml", "-Djboss.bind.address.private=$(hostname -i)"]

--- a/server-ha-postgres/src/NetInfo.java
+++ b/server-ha-postgres/src/NetInfo.java
@@ -1,0 +1,81 @@
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:jmowla@gmail.com"></a>Javad Mowlanezhasd</a>
+ */
+public class NetInfo {
+    public static void main(String... args) {
+        if (1 >= args.length) {
+            if (0 == args.length) {
+                args = new String[]{"default"};
+            } else {
+                switch (args[0]) {
+                    case "-h":
+                        System.out.println("Usage: java NetInfo [list of interfaces]");
+                        System.out.println("This utility will return IPv4 address of the first interface which has valid IP");
+                        System.out.println("The list of interfaces can be comma or space delimited.");
+                        System.out.println("If no parameter is specified it will return IP address of the hostname");
+                        System.out.println("options:\n\t-h: shows how to use!\n\t-l: shows list of all networks info");
+                        System.out.println("\nExamples:\n\tjava NetInfo eth1 eth2 default\n\tjava NetInfo eth1,eth2 default\n\tjava NetInfo");
+                        return;
+                }
+            }
+        }
+        try {
+            networkInfo(expandCommaToIndividualEntryInArgs(args));
+        } catch (SocketException ignored) {
+        }
+    }
+
+    private static void networkInfo(String... args) throws SocketException {
+        List<NetworkInterface> nets = Collections.list(NetworkInterface.getNetworkInterfaces());
+
+        if ("-l".equals(args[0])) {
+            for (NetworkInterface net : nets) {
+                List<String> addresses = new ArrayList<>();
+
+                for (InetAddress inetAddress : Collections.list(net.getInetAddresses())) {
+                    addresses.add(inetAddress.getHostAddress());
+                }
+                System.out.println(net.getIndex() + " - " + net.getName() + " : " + net.getDisplayName() + ' ' + Arrays.toString(addresses.toArray()));
+            }
+        } else {
+            for (String iface : args) {
+                if ("default".equals(iface)) {
+                    try {
+                        System.out.print(InetAddress.getByName(InetAddress.getLocalHost().getHostName()).getHostAddress());
+                    } catch (UnknownHostException ignored) {
+                    }
+                    return;
+                }
+                NetworkInterface net = NetworkInterface.getByName(iface);
+
+                if (null != net) {
+                    for (InetAddress inetAddress : Collections.list(net.getInetAddresses())) {
+                        if (inetAddress instanceof Inet4Address) {
+                            System.out.print(inetAddress.getHostAddress());
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static String[] expandCommaToIndividualEntryInArgs(String... args) {
+        List<String> expandedArgs = new ArrayList<>();
+
+        for (String arg : args) {
+            expandedArgs.addAll(Arrays.asList(arg.split(",")));
+        }
+        return expandedArgs.toArray(new String[expandedArgs.size()]);
+    }
+}


### PR DESCRIPTION
modcluster multicast listens over "private" interface which is defaulted to loopback ip (127.0.0.1)
To enable modcluster to listens on reachable IP address from other containers within network we need to send "jboss.bind.address.private"

To make this happens "jboss.bind.address.private" variable needs to be set to host's IP address, so there are two changes:
1. Dockerfile to sends extra variable
2. docker-entrypoint.sh to processes $(hostname -i) correctly. (this file will be updated during the build)