### PR TITLE
Making Proxy address forwarding configurable

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,7 @@ ENV KEYCLOAK_VERSION 3.0.0.Final
 # Enables signals getting passed from startup script to JVM
 # ensuring clean shutdown when container is stopped.
 ENV LAUNCH_JBOSS_IN_BACKGROUND 1
-
+ENV PROXY_ADDRESS_FORWARDING false
 USER root
 
 RUN yum install -y epel-release && yum install -y jq && yum clean all
@@ -12,6 +12,12 @@ RUN yum install -y epel-release && yum install -y jq && yum clean all
 USER jboss
 
 RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz | tar zx && mv /opt/jboss/keycloak-$KEYCLOAK_VERSION /opt/jboss/keycloak
+
+
+#Enabling Proxy address forwarding so we can correctly handle SSL termination in front ends
+#such as an OpenShift Router or Apache Proxy
+RUN sed -i -e 's/<http-listener /& proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING}" /' $JBOSS_HOME/standalone/configuration/standalone.xml
+
 
 ADD docker-entrypoint.sh /opt/jboss/
 

--- a/server/README.md
+++ b/server/README.md
@@ -29,6 +29,12 @@ When starting the Keycloak instance you can pass a number an environment variabl
 
     docker run -e KEYCLOAK_LOGLEVEL=DEBUG jboss/keycloak
 
+### Enabling proxy address forwarding
+
+When running Keycloak behind a proxy, you will need to enable proxy address forwarding.
+
+    docker run -e PROXY_ADDRESS_FORWARDING true jboss/keycloak
+
 ## Other details
 
 This image extends the [`jboss/base-jdk`](https://github.com/JBoss-Dockerfiles/base-jdk) image which adds the OpenJDK distribution on top of the [`jboss/base`](https://github.com/JBoss-Dockerfiles/base) image. Please refer to the README.md for selected images for more info.


### PR DESCRIPTION
I've added the ability to configure proxy address forwarding and documented how to do this in the README.

The easiest way to test it is to set a SSL edge proxy and see if the Admin Console link on the /auth page links to an http or https address.  This is easiest to set up in OpenShift as an edge terminated route.