### PR TITLE
Fix proxy address forwarding layer

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,18 +13,16 @@ USER jboss
 
 RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz | tar zx && mv /opt/jboss/keycloak-$KEYCLOAK_VERSION /opt/jboss/keycloak
 
-
-#Enabling Proxy address forwarding so we can correctly handle SSL termination in front ends
-#such as an OpenShift Router or Apache Proxy
-RUN sed -i -e 's/<http-listener /& proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING}" /' $JBOSS_HOME/standalone/configuration/standalone.xml
-
-
 ADD docker-entrypoint.sh /opt/jboss/
 
 ADD setLogLevel.xsl /opt/jboss/keycloak/
 RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/setLogLevel.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml
 
 ENV JBOSS_HOME /opt/jboss/keycloak
+
+#Enabling Proxy address forwarding so we can correctly handle SSL termination in front ends
+#such as an OpenShift Router or Apache Proxy
+RUN sed -i -e 's/<http-listener /& proxy-address-forwarding="${env.PROXY_ADDRESS_FORWARDING}" /' $JBOSS_HOME/standalone/configuration/standalone.xml
 
 EXPOSE 8080
 

--- a/server/README.md
+++ b/server/README.md
@@ -33,7 +33,7 @@ When starting the Keycloak instance you can pass a number an environment variabl
 
 When running Keycloak behind a proxy, you will need to enable proxy address forwarding.
 
-    docker run -e PROXY_ADDRESS_FORWARDING true jboss/keycloak
+    docker run -e PROXY_ADDRESS_FORWARDING=true jboss/keycloak
 
 ## Other details
 


### PR DESCRIPTION
Move the `sed` command below the definition of `JBOSS_HOME`.  It appears
standalone.xml doesn't exist at the point when the `sed` was run.
Additionally the environment variable `JBOSS_HOME` was not defined.

Also added the equals sign to the `server/README.md`. Without an equals
sign docker assumes true is the container name which causes it to fail.