### PR TITLE
Add SAML support to wildfly OIDC adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+*.swp

--- a/adapter-oidc-saml-wildfly/Dockerfile
+++ b/adapter-oidc-saml-wildfly/Dockerfile
@@ -1,0 +1,13 @@
+FROM jboss/keycloak-adapter-wildfly:2.5.5.Final
+
+ENV KEYCLOAK_VERSION 2.5.5.Final
+
+WORKDIR /opt/jboss/wildfly
+
+RUN curl -L https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/adapters/saml/keycloak-saml-wildfly-adapter-dist-$KEYCLOAK_VERSION.tar.gz | tar zx
+
+WORKDIR /opt/jboss
+
+# Standalone.xml modifications.
+RUN sed -i -e 's/<extensions>/&\n        <extension module="org.keycloak.keycloak-saml-adapter-subsystem"\/>/' $JBOSS_HOME/standalone/configuration/standalone.xml && \
+    sed -i -e 's/<profile>/&\n        <subsystem xmlns="urn:jboss:domain:keycloak-saml:1.1"\/>/' $JBOSS_HOME/standalone/configuration/standalone.xml

--- a/adapter-oidc-saml-wildfly/README.md
+++ b/adapter-oidc-saml-wildfly/README.md
@@ -1,0 +1,21 @@
+# Keycloak SAML + OIDC Wildfly Adapters
+
+This image contains Wildfly with the required bits to deploy an application that would be protected by the Keycloak subsystem, including:
+
+- Keycloak Wildfly Extension
+- Keycloak SAML Wildfly Extension
+- Keycloak Wildfly Subsystem
+- Keycloak SAML Wildfly Subsystem
+- Changes to the standalone.xml , to include both the extension and the subsystem, as well as the security-domain for Keycloak.
+
+## Usage
+
+To boot in standalone mode
+
+    docker run jboss/keycloak-adapter-wildfly
+
+## Other details
+
+This image is intended to be extended by you, to include your application to it. Without it, this image is just a Wildfly image with an extra sauce.
+
+Note that only the standalone mode is configured. If your application needs to work on domain mode as well, changes to the domain.xml similar to the ones applies to the standalone are required.


### PR DESCRIPTION
Wanted a wildfly container that included the SAML adapter, as I did not see one out there.  Went ahead and implemented.

Note that I'm currently on KC 2.5.5, so that's the version I used for this.  May want to add some tags/change for a broader coverage of versions.

Have a working test of this here: [https://hub.docker.com/r/joshcain/jboss-dockerfiles-keycloak/](https://hub.docker.com/r/joshcain/jboss-dockerfiles-keycloak/), where I've been able to successfully deploy and secure SAML applications.