### PR TITLE
Correct documented default password used for MySQL

### DIFF
--- a/server-mysql/README.md
+++ b/server-mysql/README.md
@@ -32,4 +32,4 @@ Specify user for MySQL database (optional, default is `keycloak`).
 
 #### MYSQL_PASSWORD
 
-Specify password for MySQL database (optional, default is `keycloak`).
+Specify password for MySQL database (optional, default is `password`).


### PR DESCRIPTION
The password used by default to access a MySQL database does not match
the one listed in the README file. Correct the README file.