### PR TITLE
Correct documented default database passwords

### DIFF
--- a/server-mysql/README.md
+++ b/server-mysql/README.md
@@ -32,4 +32,4 @@ Specify user for MySQL database (optional, default is `keycloak`).
 
 #### MYSQL_PASSWORD
 
-Specify password for MySQL database (optional, default is `keycloak`).
+Specify password for MySQL database (optional, default is `password`).

--- a/server-postgres/README.md
+++ b/server-postgres/README.md
@@ -32,4 +32,4 @@ Specify user for PostgreSQL database (optional, default is `keycloak`).
 
 #### POSTGRES_PASSWORD
 
-Specify password for PostgreSQL database (optional, default is `keycloak`).
+Specify password for PostgreSQL database (optional, default is `password`).


### PR DESCRIPTION
The passwords used by default to access a MySQL or PostgreSQL database
do not match the ones listed in the corresponding README files. Correct
the README files.