### PR TITLE
Change namespace version for datasources

### DIFF
--- a/server-mysql/changeDatabase.xsl
+++ b/server-mysql/changeDatabase.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ds="urn:jboss:domain:datasources:4.0">
+                xmlns:ds="urn:jboss:domain:datasources:5.0">
 
     <xsl:output method="xml" indent="yes"/>
 

--- a/server-postgres/changeDatabase.xsl
+++ b/server-postgres/changeDatabase.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ds="urn:jboss:domain:datasources:4.0">
+                xmlns:ds="urn:jboss:domain:datasources:5.0">
 
     <xsl:output method="xml" indent="yes"/>
 


### PR DESCRIPTION
Datasources namespace in Keycloak configuration files is : 
```xml
<subsystem xmlns="urn:jboss:domain:datasources:5.0">
```

The .xsl files used by Dockerfile to customize Keycloak configuration file still use 4.0 version :
```xml
<xsl:stylesheet version="2.0"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:ds="urn:jboss:domain:datasources:4.0">
```

This PR correct the problems by updating namespace versions in .xsl files