### PR TITLE
Fixes issue introduced by PR #82, bad jdbc driver file naming

### DIFF
--- a/server-postgres/Dockerfile
+++ b/server-postgres/Dockerfile
@@ -10,5 +10,5 @@ RUN rm /opt/jboss/keycloak/changeDatabase.xsl
 
 RUN mkdir -p /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main && \
   cd /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main && \
-  curl -O http://central.maven.org/maven2/org/postgresql/postgresql/$POSTGRES_JDBC_VERSION/postgresql-$POSTGRES_JDBC_VERSION.jar > postgres-jdbc.jar
+  curl -o postgres-jdbc.jar http://central.maven.org/maven2/org/postgresql/postgresql/$POSTGRES_JDBC_VERSION/postgresql-$POSTGRES_JDBC_VERSION.jar
 ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main/


### PR DESCRIPTION
With pull request #82, we end up with this situation:
```
[jboss@9c2cf66b4e19 ~]$ ls -l /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdbc/main
total 704
-rw-r--r-- 1 root  root    1354 Sep  6 09:33 module.xml
-rw-r--r-- 1 jboss jboss      0 Sep  6 09:35 postgres-jdbc.jar
-rw-r--r-- 1 jboss jboss 713037 Sep  6 09:35 postgresql-42.1.4.jar
```