### PR TITLE
Fix the broken build of the `keycloak-openshift` image

### DIFF
--- a/server-openshift/Dockerfile
+++ b/server-openshift/Dockerfile
@@ -8,8 +8,6 @@ ADD start-keycloak.sh /usr/bin/
 #Give correct permissions when used in an OpenShift environment.
 RUN chown -R jboss:0 $JBOSS_HOME/standalone && \
     chmod -R g+rw $JBOSS_HOME/standalone && \
-    chown -R jboss:0 $JBOSS_HOME/databases && \
-    chmod -R g+rw $JBOSS_HOME/databases && \
     chown -R jboss:0 $JBOSS_HOME/modules/system/layers/base && \
     chmod -R g+rw $JBOSS_HOME/modules/system/layers/base && \
     chown -R jboss:0 /tmp && \


### PR DESCRIPTION
The last change in the main image broke the build of the `keycloak-openshift` image.

This PR fixes the problem.

@stianst or anyone with commit rights, would it be possible to merge this ?

if possible it would be great if a new build with an incremented tag (`3.3.0.CR2-3` ?) could be made available soon.
We (the project I'm currently working on) are currently blocked in a release process due to this broken build, and we might be forced to build the image ourselves and host it in some other official place, which IMO would not be the best solution.

Signed-off-by: David Festal <dfestal@redhat.com>