### PR TITLE
Fix postgres container environment variables

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -81,7 +81,7 @@ Specify password for MySQL database (optional, default is `password`).
 
 First start a PostgreSQL instance using the PostgreSQL docker image:
 
-    docker run --name postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=root_password -d postgres
+    docker run --name postgres -e POSTGRES_DB=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -d postgres
 
 #### Start a Keycloak instance
 


### PR DESCRIPTION
According to [postgres official image docs](https://hub.docker.com/_/postgres/), environment variable for database name is POSTGRES_DB instead of POSTGRES_DATABASE, and no ROOT_POSTGRES_PASSWORD is available.