### PR TITLE
Fix typo from org.keycloack to org.keycloak

### DIFF
--- a/server/cli/loglevel.cli
+++ b/server/cli/loglevel.cli
@@ -1,2 +1,2 @@
-/subsystem=logging/logger=org.keycloack:add
-/subsystem=logging/logger=org.keycloack:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})
+/subsystem=logging/logger=org.keycloak:add
+/subsystem=logging/logger=org.keycloak:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})


### PR DESCRIPTION
I would have filed this just as an issue, but issues aren't available for this project.