### PR TITLE
Improve support for DEBUG level logging, including runtime level change

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -117,6 +117,8 @@ When starting the Keycloak instance you can pass a number an environment variabl
 
     docker run -e KEYCLOAK_LOGLEVEL=DEBUG jboss/keycloak
 
+Note that there are still per-package loglevel defaults.
+
 ### Enabling proxy address forwarding
 
 When running Keycloak behind a proxy, you will need to enable proxy address forwarding.

--- a/server/README.md
+++ b/server/README.md
@@ -117,6 +117,10 @@ When starting the Keycloak instance you can pass a number an environment variabl
 
     docker run -e KEYCLOAK_LOGLEVEL=DEBUG jboss/keycloak
 
+Log level can also be changed at runtime, for example (assuming docker exec access):
+
+    ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/root-logger=ROOT:change-root-log-level(level=DEBUG)'
+
 Note that there are still per-package loglevel defaults.
 
 ### Enabling proxy address forwarding

--- a/server/README.md
+++ b/server/README.md
@@ -121,7 +121,7 @@ Log level can also be changed at runtime, for example (assuming docker exec acce
 
     ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/root-logger=ROOT:change-root-log-level(level=DEBUG)'
 
-Note that there are still per-package loglevel defaults.
+Note that the `org.keycloak` package, and other `logger category` entries from config, will keep their minimum level.
 
 ### Enabling proxy address forwarding
 

--- a/server/cli/loglevel.cli
+++ b/server/cli/loglevel.cli
@@ -2,8 +2,9 @@
 /subsystem=logging/logger=org.keycloak:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})
 /subsystem=logging/root-logger=ROOT:change-root-log-level(level=${env.KEYCLOAK_LOGLEVEL:INFO})
 
-/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})
-
 # logging to file is uninteresting in docker
 /subsystem=logging/periodic-rotating-file-handler=FILE:remove
 /subsystem=logging/root-logger=ROOT:remove-handler(name="FILE")
+
+# with file logging removed, don't reduce log level for console
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=TRACE)

--- a/server/cli/loglevel.cli
+++ b/server/cli/loglevel.cli
@@ -1,2 +1,9 @@
 /subsystem=logging/logger=org.keycloak:add
 /subsystem=logging/logger=org.keycloak:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})
+/subsystem=logging/root-logger=ROOT:change-root-log-level(level=${env.KEYCLOAK_LOGLEVEL:INFO})
+
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=${env.KEYCLOAK_LOGLEVEL:INFO})
+
+# logging to file is uninteresting in docker
+/subsystem=logging/periodic-rotating-file-handler=FILE:remove
+/subsystem=logging/root-logger=ROOT:remove-handler(name="FILE")


### PR DESCRIPTION
The README includes an instruction for loglevel change, by env var, that has no effect because:
- Docker users only see stdout (not file logging)
- Not a lot of logging comes from `org.keycloak` package, which the env regulated. Most is from `org.jboss`.

In addition, runtime log level change is a great feature for troubleshooting. Keycloak supports that, so I documented a hint on how to use it.