### PR TITLE
Using latest postgres JDBC 4.2 driver

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,7 +19,7 @@ ADD cli /opt/jboss/keycloak/cli
 RUN cd /opt/jboss/keycloak && bin/jboss-cli.sh --file=cli/standalone-configuration.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 RUN cd /opt/jboss/keycloak && bin/jboss-cli.sh --file=cli/standalone-ha-configuration.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 
-ENV JDBC_POSTGRES_VERSION 42.1.4
+ENV JDBC_POSTGRES_VERSION 42.2.2
 ENV JDBC_MYSQL_VERSION 5.1.18
 ENV JDBC_MARIADB_VERSION 2.2.3
 


### PR DESCRIPTION
In March 2018 the Postgres team did release the `42.2.2` as its current version 