### PR TITLE
add missing mandatory DB_VENDOR env vars

### DIFF
--- a/docker-compose-examples/README.md
+++ b/docker-compose-examples/README.md
@@ -6,26 +6,26 @@ Examples for using Keycloak with Docker Compose
 
 ## Keycloak and PostgreSQL
 
-The `keycloak-postgres.yml` template creates a volume for PostgreSQL and starts Keycloak connected to a PostgreSQL instace. 
+The `keycloak-postgres.yml` template creates a volume for PostgreSQL and starts Keycloak connected to a PostgreSQL instance.
 
 Run the example with the following command:
 
     docker-compose -f keycloak-postgres.yml up
-    
+
 Open http://localhost:8080/auth and login as user 'admin' with password 'Pa55w0rd'.
 
 Note - If you run the example twice without removing the persisted volume there will be a warning 'user with username exists'. You can ignore this warning.
-    
+
 
 
 ## Keycloak and MySQL
 
-The `keycloak-mysql.yml` template creates a volume for MySQL and starts Keycloak connected to a MySQL instace. 
+The `keycloak-mysql.yml` template creates a volume for MySQL and starts Keycloak connected to a MySQL instance.
 
 Run the example with the following command:
 
     docker-compose -f keycloak-mysql.yml up
-    
+
 Note - This example is not currently working as MySQL is not ready to receive connections when Keycloak is started.
 
 
@@ -36,4 +36,4 @@ Note - This example is not currently working as MySQL is not ready to receive co
 
 If you get a error `Failed to add user 'admin' to realm 'master': user with username exists` this is most likely because
 you've already ran the example, but not deleted the persisted volume for the database. In this case the admin user already
-exists. You can ignore this warning or delete the volume before trying again. 
+exists. You can ignore this warning or delete the volume before trying again.

--- a/docker-compose-examples/keycloak-mysql.yml
+++ b/docker-compose-examples/keycloak-mysql.yml
@@ -17,6 +17,7 @@ services:
   keycloak:
       image: jboss/keycloak
       environment:
+        DB_VENDOR: MYSQL
         DB_ADDR: mysql
         DB_DATABASE: keycloak
         DB_USER: keycloak

--- a/docker-compose-examples/keycloak-postgres.yml
+++ b/docker-compose-examples/keycloak-postgres.yml
@@ -16,6 +16,7 @@ services:
   keycloak:
       image: jboss/keycloak
       environment:
+        DB_VENDOR: POSTGRES
         DB_ADDR: postgres
         DB_DATABASE: keycloak
         DB_USER: keycloak


### PR DESCRIPTION
As indicated on https://hub.docker.com/r/jboss/keycloak/
the DB_VENDOR env var is mandatory.