### PR TITLE
Update to Keycloak 4.0.0.Beta2

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM jboss/base-jdk:8
 
-ENV KEYCLOAK_VERSION 3.2.0.Final
+ENV KEYCLOAK_VERSION 4.0.0.Beta2
 USER jboss
 RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/${KEYCLOAK_VERSION}/keycloak-proxy-${KEYCLOAK_VERSION}.zip | jar xvf /dev/stdin && mv /opt/jboss/keycloak-proxy-${KEYCLOAK_VERSION} /opt/jboss/keycloak-proxy
 ADD docker-entrypoint.sh /opt/jboss/


### PR DESCRIPTION
Fix the incorrect build already tagged and released

All Tags: https://hub.docker.com/r/jboss/keycloak-proxy/tags/
Broken Image due to ENV version: https://hub.docker.com/r/jboss/keycloak-proxy/builds/bazgrwb9zydzuscesa7rkcc/