### PR TITLE
Bumps MySQL Driver version to 5.1.46 to support MySQL 8

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /opt/jboss/keycloak && bin/jboss-cli.sh --file=cli/standalone-configurati
 RUN cd /opt/jboss/keycloak && bin/jboss-cli.sh --file=cli/standalone-ha-configuration.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 
 ENV JDBC_POSTGRES_VERSION 42.2.2
-ENV JDBC_MYSQL_VERSION 5.1.18
+ENV JDBC_MYSQL_VERSION 5.1.46
 ENV JDBC_MARIADB_VERSION 2.2.3
 
 ADD databases/change-database.sh /opt/jboss/keycloak/bin/change-database.sh

--- a/server/databases/mysql/module.xml
+++ b/server/databases/mysql/module.xml
@@ -22,7 +22,7 @@
   -->
 <module xmlns="urn:jboss:module:1.0" name="com.mysql.jdbc">
   <resources>
-    <resource-root path="mysql-connector-java-5.1.18.jar"/>
+    <resource-root path="mysql-connector-java-5.1.46.jar"/>
   </resources>
   <dependencies>
     <module name="javax.api"/>


### PR DESCRIPTION
I also sent an email to the keycloak dev list to discuss this. https://lists.jboss.org/pipermail/keycloak-dev/2018-May/010815.html