### PR TITLE
Keycloak HA Profile

### DIFF
--- a/server-ha/Dockerfile
+++ b/server-ha/Dockerfile
@@ -1,0 +1,10 @@
+FROM jboss/keycloak:latest
+
+ADD docker-entrypoint-ha.sh /opt/jboss/docker-entrypoint-ha.sh
+
+EXPOSE 55200
+EXPOSE 45688
+
+ENTRYPOINT ["/opt/jboss/docker-entrypoint-ha.sh"]
+
+CMD ["-b", "0.0.0.0","--server-config", "standalone-ha.xml"]

--- a/server-ha/README.md
+++ b/server-ha/README.md
@@ -1,0 +1,26 @@
+# Keycloak HA PostgreSQL
+
+Example Docker file for clustered Keycloak using a PostgreSQL
+
+## Usage
+
+### Start a PostgreSQL instance
+
+First start a PostgreSQL instance using the PostgreSQL docker image:
+
+    docker run --name postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=password -d postgres
+
+### Start a Keycloak HA instance
+
+Start two or more Keycloak instances that form a cluster and connect to the PostgreSQL instance running in previously started 'postgres' container:
+
+    docker run --name keycloak --link postgres:postgres -e DB_DATABASE=keycloak -e DB_USER=keycloak -e DB_PASSWORD=password jboss/keycloak-ha-postgres
+    docker logs -f keycloak
+
+    docker run --name keycloak2 --link postgres:postgres -e DB_DATABASE=keycloak -e DB_USER=keycloak -e DB_PASSWORD=password jboss/keycloak-ha-postgres
+    docker logs -f keycloak2
+
+
+## Other details
+
+This image extends the [`jboss/keycloak-postgres`](https://github.com/jboss-dockerfiles/keycloak) image. Please refer to the README.md for selected images for more info.

--- a/server-ha/README.md
+++ b/server-ha/README.md
@@ -1,26 +1,62 @@
-# Keycloak HA PostgreSQL
+# Keycloak Docker image
 
-Example Docker file for clustered Keycloak using a PostgreSQL
+Keycloak HA Server Docker image.
 
 ## Usage
 
-### Start a PostgreSQL instance
+Settings are same like in jboss/keycloak image.
 
-First start a PostgreSQL instance using the PostgreSQL docker image:
+## Expose on localhost
 
-    docker run --name postgres -e POSTGRES_DATABASE=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -e POSTGRES_ROOT_PASSWORD=password -d postgres
+To be able to open Keycloak on localhost map port 8080 locally
 
-### Start a Keycloak HA instance
-
-Start two or more Keycloak instances that form a cluster and connect to the PostgreSQL instance running in previously started 'postgres' container:
-
-    docker run --name keycloak --link postgres:postgres -e DB_DATABASE=keycloak -e DB_USER=keycloak -e DB_PASSWORD=password jboss/keycloak-ha-postgres
-    docker logs -f keycloak
-
-    docker run --name keycloak2 --link postgres:postgres -e DB_DATABASE=keycloak -e DB_USER=keycloak -e DB_PASSWORD=password jboss/keycloak-ha-postgres
-    docker logs -f keycloak2
+    docker run -p 8080:8080 jboss/keycloak-ha
 
 
+#### Example with PostgreSQL
+
+##### Start a PostgreSQL instance
+
+    docker run --name postgres -e POSTGRES_DB=keycloak -e POSTGRES_USER=keycloak -e POSTGRES_PASSWORD=password -d postgres
+
+##### Start a Keycloak instances
+
+    docker run --name keycloak1 jboss/keycloak-ha
+    docker run --name keycloak2 jboss/keycloak-ha
+
+##### Docker Compose Example
+    
+    version: "3.2"
+    services:
+      keycloak:
+        image: jboss/keycloak-ha:latest
+        restart: always
+        deploy:
+          replicas: 2
+        ports:
+          - "8080:8080"
+        networks:
+          - devnet
+      postgres:
+        image: postgres:latest
+        restart: always
+        environment:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: keycloak
+          POSTGRES_DB: keycloak
+        deploy:
+          replicas: 1
+          placement:
+            constraints: [node.role == manager]
+        networks:
+          - devnet
+    networks:
+        devnet:
+    
+    
+    
 ## Other details
 
-This image extends the [`jboss/keycloak-postgres`](https://github.com/jboss-dockerfiles/keycloak) image. Please refer to the README.md for selected images for more info.
+This image extends the [`jboss/base-jdk`](https://github.com/JBoss-Dockerfiles/base-jdk) image which adds the OpenJDK
+distribution on top of the [`jboss/base`](https://github.com/JBoss-Dockerfiles/base) image. Please refer to the README.md
+for selected images for more info.

--- a/server-ha/cccp.yml
+++ b/server-ha/cccp.yml
@@ -1,0 +1,3 @@
+# This is for the purpose of building container
+# on container pipeline
+job-id: keycloak-ha-postgres

--- a/server-ha/docker-entrypoint-ha.sh
+++ b/server-ha/docker-entrypoint-ha.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./opt/jboss/add-admin.sh
+
+./opt/jboss/add-datasource.sh
+
+# Start Keycloak
+
+HOST_IP=$(hostname -i)
+
+exec /opt/jboss/keycloak/bin/standalone.sh -bprivate ${HOST_IP} $@
+
+exit $?
+ 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,6 +14,8 @@ USER jboss
 RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz | tar zx && mv /opt/jboss/keycloak-$KEYCLOAK_VERSION /opt/jboss/keycloak
 
 ADD docker-entrypoint.sh /opt/jboss/
+ADD add-admin.sh /opt/jboss/
+ADD add-datasource.sh /opt/jboss/
 
 ADD cli /opt/jboss/keycloak/cli
 RUN cd /opt/jboss/keycloak && bin/jboss-cli.sh --file=cli/standalone-configuration.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history

--- a/server/add-admin.sh
+++ b/server/add-admin.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Add admin user
+if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
+    keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+fi
+
+

--- a/server/add-datasource.sh
+++ b/server/add-datasource.sh
@@ -1,0 +1,78 @@
+ #!/bin/bash
+ 
+ # Support deprecated '--link'
+
+if [ "$DB_PORT_3306_TCP_ADDR" != "" ]; then
+    export DB_ADDR="$DB_PORT_3306_TCP_ADDR"
+fi
+
+if [ "$DB_PORT_3306_TCP_PORT" != "" ]; then
+    export DB_PORT="$DB_PORT_3306_TCP_PORT"
+fi
+
+if [ "$DB_PORT_5432_TCP_ADDR" != "" ]; then
+    export DB_ADDR="$DB_PORT_5432_TCP_ADDR"
+fi
+
+if [ "$DB_PORT_5432_TCP_PORT" != "" ]; then
+    export DB_PORT="$DB_PORT_5432_TCP_PORT"
+fi
+
+if [ "$DB_PORT_3306_TCP_ADDR" != "" ]; then
+    export DB_ADDR="$DB_PORT_3306_TCP_ADDR"
+fi
+
+if [ "$DB_PORT_3306_TCP_PORT" != "" ]; then
+    export DB_PORT="$DB_PORT_3306_TCP_PORT"
+fi
+
+# Detect DB vendor
+if [ "$DB_VENDOR" == "POSTGRES" ]; then
+    export DB_VENDOR="postgres"
+    DB_NAME="PostgreSQL"
+elif [ "$DB_VENDOR" == "MYSQL" ]; then
+    export DB_VENDOR="mysql"
+    DB_NAME="MySQL"
+elif [ "$DB_VENDOR" == "MARIADB" ]; then
+    export DB_VENDOR="mariadb"
+    DB_NAME="MariaDB"
+elif [ "$DB_VENDOR" == "H2" ]; then
+    export DB_VENDOR="h2"
+    DB_NAME="embedded H2"
+else
+    echo "Missing mandatory environment variable DB_VENDOR. Allowed values are [H2, POSTGRES, MYSQL, MARIADB]"
+    exit 1
+fi
+
+# Append '?' in the beggining of the string if JDBC_PARAMS value isn't empty
+export JDBC_PARAMS=$(echo ${JDBC_PARAMS} | sed '/^$/! s/^/?/')
+
+###
+# Keep for backward compatibility
+###
+function set_legacy_vars() {
+  local suffixes=(ADDR DATABASE USER PASSWORD)
+  for suffix in "${suffixes[@]}"; do
+    local varname="$1_$suffix"
+    if [ ${!varname} ]; then
+      echo WARNING: $varname variable name is DEPRECATED consider using DB_$suffix
+      export DB_$suffix=${!varname}
+    fi
+  done
+}
+
+set_legacy_vars $DB_VENDOR
+###
+
+# Configure DB
+
+echo "========================================================================="
+echo ""
+echo "  Using $DB_NAME database"
+echo ""
+echo "========================================================================="
+echo ""
+
+if [ "$DB_VENDOR" != "h2" ]; then
+    /bin/sh /opt/jboss/keycloak/bin/change-database.sh $DB_VENDOR
+fi

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,91 +1,11 @@
 #!/bin/bash
 
-# Add admin user
-if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
-    keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
-fi
+./opt/jboss/keycloak/add-admin.sh
 
-
-# Support deprecated '--link'
-
-if [ "$DB_PORT_3306_TCP_ADDR" != "" ]; then
-    export DB_ADDR="$DB_PORT_3306_TCP_ADDR"
-fi
-
-if [ "$DB_PORT_3306_TCP_PORT" != "" ]; then
-    export DB_PORT="$DB_PORT_3306_TCP_PORT"
-fi
-
-if [ "$DB_PORT_5432_TCP_ADDR" != "" ]; then
-    export DB_ADDR="$DB_PORT_5432_TCP_ADDR"
-fi
-
-if [ "$DB_PORT_5432_TCP_PORT" != "" ]; then
-    export DB_PORT="$DB_PORT_5432_TCP_PORT"
-fi
-
-if [ "$DB_PORT_3306_TCP_ADDR" != "" ]; then
-    export DB_ADDR="$DB_PORT_3306_TCP_ADDR"
-fi
-
-if [ "$DB_PORT_3306_TCP_PORT" != "" ]; then
-    export DB_PORT="$DB_PORT_3306_TCP_PORT"
-fi
-
-# Detect DB vendor
-if [ "$DB_VENDOR" == "POSTGRES" ]; then
-    export DB_VENDOR="postgres"
-    DB_NAME="PostgreSQL"
-elif [ "$DB_VENDOR" == "MYSQL" ]; then
-    export DB_VENDOR="mysql"
-    DB_NAME="MySQL"
-elif [ "$DB_VENDOR" == "MARIADB" ]; then
-    export DB_VENDOR="mariadb"
-    DB_NAME="MariaDB"
-elif [ "$DB_VENDOR" == "H2" ]; then
-    export DB_VENDOR="h2"
-    DB_NAME="embedded H2"
-else
-    echo "Missing mandatory environment variable DB_VENDOR. Allowed values are [H2, POSTGRES, MYSQL, MARIADB]"
-    exit 1
-fi
-
-# Append '?' in the beggining of the string if JDBC_PARAMS value isn't empty
-export JDBC_PARAMS=$(echo ${JDBC_PARAMS} | sed '/^$/! s/^/?/')
-
-###
-# Keep for backward compatibility
-###
-function set_legacy_vars() {
-  local suffixes=(ADDR DATABASE USER PASSWORD)
-  for suffix in "${suffixes[@]}"; do
-    local varname="$1_$suffix"
-    if [ ${!varname} ]; then
-      echo WARNING: $varname variable name is DEPRECATED consider using DB_$suffix
-      export DB_$suffix=${!varname}
-    fi
-  done
-}
-
-set_legacy_vars $DB_VENDOR
-###
-
-# Configure DB
-
-echo "========================================================================="
-echo ""
-echo "  Using $DB_NAME database"
-echo ""
-echo "========================================================================="
-echo ""
-
-if [ "$DB_VENDOR" != "h2" ]; then
-    /bin/sh /opt/jboss/keycloak/bin/change-database.sh $DB_VENDOR
-fi
-
-
+./opt/jboss/keycloak/add-datasource.sh
 
 # Start Keycloak
 
 exec /opt/jboss/keycloak/bin/standalone.sh $@
+
 exit $?


### PR DESCRIPTION
In image keycloak-ha-postgres, keycloak binds private interface to 127.0.0.1, by default. So because jgroups uses private interface for communicating, nodes cannot see each other, and cannot make cluster. In this fix nodes are using container IP for private interface (0.0.0.0 is not valid ip for udp).  Also IP of private interface can be overridden in CMD in Dockerfile, if desired. Additional files (add-admin.sh and add-datasource.sh) are created for reducing boilerplate code because new docker entrypoint is created. Ports 55200 and 45688 are exposed.
This will automate clustering, and enable quick scaling of nodes in docker compose. Like in readme.md example.

