### PR TITLE
Fix java.lang.NoClassDefFoundError: sun/security/ssl/SupportedEllipti…

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@ ENV KEYCLOAK_VERSION 4.0.0.Final
 USER jboss
 RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/${KEYCLOAK_VERSION}/keycloak-proxy-${KEYCLOAK_VERSION}.zip | jar xvf /dev/stdin && mv /opt/jboss/keycloak-proxy-${KEYCLOAK_VERSION} /opt/jboss/keycloak-proxy
 ADD docker-entrypoint.sh /opt/jboss/
-RUN curl http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.11.v20170118/alpn-boot-8.1.11.v20170118.jar -o /opt/jboss/keycloak-proxy/lib/alpn-boot.jar
+RUN curl http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar -o /opt/jboss/keycloak-proxy/lib/alpn-boot.jar
 VOLUME /opt/jboss/conf
 EXPOSE 8080
 ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]


### PR DESCRIPTION
There seems to have an incompatibility issue between the jdk version:

```
openjdk version "1.8.0_161"
OpenJDK Runtime Environment (build 1.8.0_161-b14)
OpenJDK 64-Bit Server VM (build 25.161-b14, mixed mode)
```

And alpn-boot.jar version [compatibility table](http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions) should be 8.1.12.v20180117 and not 8.1.11.v20170118.

After update the following disapear:

```
keycloak-proxy_1  | java.lang.NoClassDefFoundError: sun/security/ssl/SupportedEllipticCurvesExtension
keycloak-proxy_1  | 	at sun.security.ssl.ClientHandshaker.getKickstartMessage(ClientHandshaker.java:1438)
keycloak-proxy_1  | 	at sun.security.ssl.Handshaker.kickstart(Handshaker.java:1087)
keycloak-proxy_1  | 	at sun.security.ssl.SSLSocketImpl.kickstartHandshake(SSLSocketImpl.java:1497)
keycloak-proxy_1  | 	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1361)
keycloak-proxy_1  | 	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1413)
keycloak-proxy_1  | 	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1397)

```