### PR TITLE
Added KeyCloak data directory to keycloak service

### DIFF
--- a/docker-compose-examples/keycloak-mysql.yml
+++ b/docker-compose-examples/keycloak-mysql.yml
@@ -3,6 +3,8 @@ version: '3'
 volumes:
   mysql_data:
       driver: local
+  kc_data:
+      driver: local
 
 services:
   mysql:
@@ -16,6 +18,8 @@ services:
         MYSQL_PASSWORD: password
   keycloak:
       image: jboss/keycloak
+      volumes:
+        - kc_data:/opt/jboss/keycloak/standalone/data
       environment:
         DB_VENDOR: MYSQL
         DB_ADDR: mysql

--- a/docker-compose-examples/keycloak-postgres.yml
+++ b/docker-compose-examples/keycloak-postgres.yml
@@ -3,6 +3,8 @@ version: '3'
 volumes:
   postgres_data:
       driver: local
+  kc_data:
+      driver: local
 
 services:
   postgres:
@@ -15,6 +17,8 @@ services:
         POSTGRES_PASSWORD: password
   keycloak:
       image: jboss/keycloak
+      volumes:
+        - kc_data:/opt/jboss/keycloak/standalone/data
       environment:
         DB_VENDOR: POSTGRES
         DB_ADDR: postgres


### PR DESCRIPTION
To persist the KeyCloak data, we have to mount a volume for the /opt/jboss/keycloak/standalone/data dir. This dir must have 1000:1000 (jboss:jboss) ownership.