### PR TITLE
https-listener also honor proxy-address-forwarding setting

### DIFF
--- a/server/cli/proxy.cli
+++ b/server/cli/proxy.cli
@@ -1,1 +1,2 @@
 /subsystem=undertow/server=default-server/http-listener=default: write-attribute(name=proxy-address-forwarding, value=${env.PROXY_ADDRESS_FORWARDING})
+/subsystem=undertow/server=default-server/https-listener=default: write-attribute(name=proxy-address-forwarding, value=${env.PROXY_ADDRESS_FORWARDING})


### PR DESCRIPTION
Ensure correct ip addresses show up in logging when https is used between proxy and keycloak.