### PR TITLE
KEYCLOAK-7891 OpenShift managed SSL certificates

### DIFF
--- a/openshift-examples/README.md
+++ b/openshift-examples/README.md
@@ -1,0 +1,6 @@
+# Keycloak OpenShift examples
+
+This directory contains a set of predefined OpenShift templates for running Keycloak, including:
+
+* `keycloak-https.json` - A standard template for most of the use cases. It uses both HTTP and HTTPS routes.
+* `keycloak-https-mutual-tls.json` - A similar template to the one above but uses OpenShift generated certificates to setup Mutual TLS.

--- a/openshift-examples/keycloak-https-mutual-tls.json
+++ b/openshift-examples/keycloak-https-mutual-tls.json
@@ -1,0 +1,242 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "keycloak-https",
+        "annotations": {
+            "iconClass": "icon-sso",
+            "tags": "keycloak",
+            "version": "4.0.0.Beta2",
+            "openshift.io/display-name": "Keycloak",
+            "description": "An example Keycloak server with HTTPS"
+        }
+    },
+    "parameters": [
+        {
+            "displayName": "Application Name",
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "keycloak",
+            "required": true
+        },
+        {
+            "displayName": "Keycloak Administrator Username",
+            "description": "Keycloak Server administrator username",
+            "name": "KEYCLOAK_USER",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "Keycloak Administrator Password",
+            "description": "Keycloak Server administrator password",
+            "name": "KEYCLOAK_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "DB Vendor",
+            "description": "DB vendor (H2, POSTGRES, MYSQL or MARIADB)",
+            "name": "DB_VENDOR",
+            "value": "H2",
+            "required": true
+        },
+        {
+            "displayName": "Custom http Route Hostname",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Custom https Route Hostname",
+            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTPS",
+            "value": "",
+            "required": false
+        }
+    ],
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The web server's http port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/serving-cert-secret-name": "keycloak-x509-https-secret"
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's http service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's https service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTPS}",
+                "to": {
+                    "name": "secure-${APPLICATION_NAME}"
+                },
+                "tls": {
+                    "termination": "passthrough"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}",
+                                "image": "jboss/keycloak-openshift",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "https",
+                                        "containerPort": 8443,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KEYCLOAK_USER",
+                                        "value": "${KEYCLOAK_USER}"
+                                    },
+                                    {
+                                        "name": "KEYCLOAK_PASSWORD",
+                                        "value": "${KEYCLOAK_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_VENDOR",
+                                        "value": "${DB_VENDOR}"
+                                    },
+                                    {
+                                        "name": "X509_CA_BUNDLE",
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                    }
+                                ],
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "keycloak-x509-https-volume",
+                                        "mountPath": "/etc/x509/https",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "keycloak-x509-https-volume",
+                                "secret": {
+                                    "secretName": "keycloak-x509-https-secret"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloa
 
 USER root
 
-RUN yum install -y epel-release git && yum install -y jq && yum clean all
+RUN yum install -y epel-release git && yum install -y jq openssl which && yum clean all
 
 ADD tools /opt/jboss/tools
 RUN /opt/jboss/tools/build-keycloak.sh

--- a/server/README.md
+++ b/server/README.md
@@ -184,6 +184,22 @@ When running Keycloak behind a proxy, you will need to enable proxy address forw
 
 
 
+### Setting up TLS(SSL)
+
+Keycloak image allows you to specify both a private key and a certificate for serving HTTPS. In that case you need to provide two files:
+
+* tls.crt - a certificate
+* tls.key - a private key
+
+Those files need to be mounted in `/etc/x509/https` directory. The image will automatically convert them into a Java keystore and reconfigure Wildfly to use it.
+
+It is also possible to provide an additional CA bundle and setup Mutual TLS this way. In that case, you need to mount an additional volume to the image
+containing a `crt` file and point `X509_CA_BUNDLE` environmental variable to that file. 
+
+NOTE: See `openshift-examples` directory for an out of the box setup for OpenShift.
+
+
+
 ## Other details
 
 This image extends the [`jboss/base-jdk`](https://github.com/JBoss-Dockerfiles/base-jdk) image which adds the OpenJDK

--- a/server/tools/cli/x509-keystore.cli
+++ b/server/tools/cli/x509-keystore.cli
@@ -1,0 +1,9 @@
+embed-server --server-config=$configuration_file --std-out=discard
+/subsystem=elytron/key-store=kcKeyStore:add(path=$keycloak_tls_keystore_file,type=JKS,credential-reference={clear-text=$keycloak_tls_keystore_password})
+/subsystem=elytron/key-manager=kcKeyManager:add(key-store=kcKeyStore,credential-reference={clear-text=$keycloak_tls_keystore_password})
+/subsystem=elytron/server-ssl-context=kcSSLContext:add(key-manager=kcKeyManager)
+batch
+/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=kcSSLContext)
+run-batch
+stop-embedded-server

--- a/server/tools/cli/x509-truststore.cli
+++ b/server/tools/cli/x509-truststore.cli
@@ -1,0 +1,15 @@
+embed-server --server-config=$configuration_file --std-out=discard
+/subsystem=elytron/key-store=kcTrustStore:add(path=$keycloak_tls_truststore_file,type=JKS,credential-reference={clear-text=$keycloak_tls_truststore_password})
+/subsystem=elytron/trust-manager=kcTrustManager:add(key-store=kcTrustStore)
+if (outcome != success) of /subsystem=elytron/server-ssl-context=kcSSLContext:read-resource
+	/subsystem=elytron/server-ssl-context=kcSSLContext:add(trust-manager=kcTrustManager,need-client-auth=true)
+	batch
+	/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
+	/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=kcSSLContext)
+	run-batch
+else
+    # The SSL Context has been added by keystore, not much to do - just append trust store and we are done.
+	/subsystem=elytron/server-ssl-context=kcSSLContext:write-attribute(name=trust-manager, value=kcTrustManager)
+    /subsystem=elytron/server-ssl-context=kcSSLContext:write-attribute(name=need-client-auth, value=true)
+end-if
+stop-embedded-server

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -94,6 +94,8 @@ if [ "$DB_VENDOR" != "h2" ]; then
     /bin/sh /opt/jboss/tools/change-database.sh $DB_VENDOR
 fi
 
+/opt/jboss/tools/x509.sh
+
 ##################
 # Start Keycloak #
 ##################

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+function autogenerate_keystores() {
+  # Keystore infix notation as used in templates to keystore name mapping
+  declare -A KEYSTORES=( ["https"]="HTTPS" )
+
+  local KEYSTORES_STORAGE="${JBOSS_HOME}/standalone/configuration/keystores"
+  if [ ! -d "${KEYSTORES_STORAGE}" ]; then
+    mkdir -p "${KEYSTORES_STORAGE}"
+  fi
+
+  # Auto-generate the HTTPS keystore if volumes for OpenShift's
+  # serving x509 certificate secrets service were properly mounted
+  for KEYSTORE_TYPE in "${!KEYSTORES[@]}"; do
+
+    local X509_KEYSTORE_DIR="/etc/x509/${KEYSTORE_TYPE}"
+    local X509_CRT="tls.crt"
+    local X509_KEY="tls.key"
+    local NAME="keycloak-${KEYSTORE_TYPE}-key"
+    local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+    local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
+    local PKCS12_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.pk12"
+
+    if [ -d "${X509_KEYSTORE_DIR}" ]; then
+
+      echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
+
+      openssl pkcs12 -export \
+      -name "${NAME}" \
+      -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+      -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+      -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+      -password pass:"${PASSWORD}" >& /dev/null
+
+      keytool -importkeystore -noprompt \
+      -srcalias "${NAME}" -destalias "${NAME}" \
+      -srckeystore "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+      -srcstoretype pkcs12 \
+      -destkeystore "${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" \
+      -storepass "${PASSWORD}" -srcstorepass "${PASSWORD}" >& /dev/null
+
+      if [ -f "${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" ]; then
+        echo "${KEYSTORES[$KEYSTORE_TYPE]} keystore successfully created at: ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}"
+      fi
+
+      echo "set keycloak_tls_keystore_password=${PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
+      echo "set keycloak_tls_keystore_file=${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" >> "$JBOSS_HOME/bin/.jbossclirc"
+      echo "set configuration_file=standalone.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+      $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-keystore.cli >& /dev/null
+      sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+      echo "set configuration_file=standalone-ha.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+      $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-keystore.cli >& /dev/null
+      sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+    fi
+
+  done
+
+  # Auto-generate the Keycloak truststore if X509_CA_BUNDLE was provided
+  local -r X509_CRT_DELIMITER="/-----BEGIN CERTIFICATE-----/"
+  local JKS_TRUSTSTORE_FILE="truststore.jks"
+  local JKS_TRUSTSTORE_PATH="${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}"
+  local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+  if [ -n "${X509_CA_BUNDLE}" ]; then
+    pushd /tmp >& /dev/null
+    echo "Creating Keycloak truststore.."
+    csplit -s -z -f crt- "${X509_CA_BUNDLE}" "${X509_CRT_DELIMITER}" '{*}'
+    for CERT_FILE in crt-*; do
+      keytool -import -noprompt -keystore "${JKS_TRUSTSTORE_PATH}" -file "${CERT_FILE}" \
+      -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null
+    done
+
+    if [ -f "${JKS_TRUSTSTORE_PATH}" ]; then
+      echo "Keycloak truststore successfully created at: ${JKS_TRUSTSTORE_PATH}"
+    fi
+
+    # Import existing system CA certificates into the newly generated truststore
+    local SYSTEM_CACERTS=$(readlink -e $(dirname $(readlink -e $(which keytool)))"/../lib/security/cacerts")
+    if keytool -v -list -keystore "${SYSTEM_CACERTS}" -storepass "changeit" > /dev/null; then
+      echo "Importing certificates from system's Java CA certificate bundle into Keycloak truststore.."
+      keytool -importkeystore -noprompt \
+      -srckeystore "${SYSTEM_CACERTS}" \
+      -destkeystore "${JKS_TRUSTSTORE_PATH}" \
+      -srcstoretype jks -deststoretype jks \
+      -storepass "${PASSWORD}" -srcstorepass "changeit" >& /dev/null
+      if [ "$?" -ne "0" ]; then
+        echo "Successfully imported certificates from system's Java CA certificate bundle into Keycloak truststore at: ${JKS_TRUSTSTORE_PATH}"
+      else
+        echo "Failed to import certificates from system's Java CA certificate bundle into Keycloak truststore!"
+      fi
+    fi
+
+    echo "set keycloak_tls_truststore_password=${PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set keycloak_tls_truststore_file=${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set configuration_file=standalone.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+    $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-truststore.cli >& /dev/null
+    sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set configuration_file=standalone-ha.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+    $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-truststore.cli >& /dev/null
+    sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+
+    popd >& /dev/null
+  fi
+}
+
+autogenerate_keystores


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-7891

This PR introduces automatic generation of Keystore/Truststore based on provided PEM files. It has been implemented very [similarly to the product](https://github.com/jboss-openshift/cct_module/blob/master/os-sso72/added/launch/openshift-x509.sh) (mostly for symmetry reasons). However, there are some things that has been changed:

* I'm using CLI instead of manipulating XML configuration directly
* OpenSSL generated a warning message when generating new random values. I silenced it out.
* I removed extracting JGroups secret (I think it doesn't bring any value to the table at the moment).

Possible things to consider:

* CA Bundle path is specified by an environmental variable whereas `tls.crt` and `tls.key` are expected to be mounted in some path. This lack of symmetry can be fixed by either introducing 2 new environmental variables pointing to `tls.crt` and `tls.key`. Removing `X509_CA_BUNDLE` is probably not an option since CA bundle is in different place in OpenShift and Kubernetes.
* Introduce a switch to ignore Keystore/Truststore settings, set it to `true` (meaning, yes please ignore those settings) and squash `keycloak-https-mutual-tls.json` and `keycloak-https.json` together.
