### PR TITLE
Feature/fix docker entrypoint

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -91,6 +91,7 @@ echo "========================================================================="
 echo ""
 
 if [ "$DB_VENDOR" != "h2" ]; then
+    ln -s /opt/jboss/tools/cli /opt/jboss/keycloak/cli
     /bin/sh /opt/jboss/tools/databases/change-database.sh $DB_VENDOR
 fi
 

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -91,7 +91,7 @@ echo "========================================================================="
 echo ""
 
 if [ "$DB_VENDOR" != "h2" ]; then
-    /bin/sh /opt/jboss/tools/change-database.sh $DB_VENDOR
+    /bin/sh /opt/jboss/tools/databases/change-database.sh $DB_VENDOR
 fi
 
 ##################


### PR DESCRIPTION
Keycloak fails to start with a DB, always falls back to H2

The second commit fixes the following message during startup:

> The batch failed with the following error: : File /opt/jboss/keycloak/cli/databases/mysql/change-database.cli does not exist.

I couldn't fix the root cause because I don't know what is trying to access this path, hence the simple workaround with a symlink.