### PR TITLE
KEYCLOAK-7582 Discovery protocol support

### DIFF
--- a/openshift-examples/keycloak-https-mutual-tls.json
+++ b/openshift-examples/keycloak-https-mutual-tls.json
@@ -55,6 +55,12 @@
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
+        },
+        {
+            "displayName": "Namespace used for DNS discovery",
+            "description": "This namespace is a part of DNS query sent to Kubernetes API. This query allows the DNS_PING protocol to extract cluster members. This parameter might be removed once https://issues.jboss.org/browse/JGRP-2292 is implemented.",
+            "name": "NAMESPACE",
+            "required": true
         }
     ],
     "objects": [
@@ -212,6 +218,14 @@
                                     {
                                         "name": "X509_CA_BUNDLE",
                                         "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                    },
+                                    {
+                                        "name": "JGROUPS_DISCOVERY_PROTOCOL",
+                                        "value": "dns.DNS_PING"
+                                    },
+                                    {
+                                        "name": "JGROUPS_DISCOVERY_PROPERTIES",
+                                        "value": "${APPLICATION_NAME}.${NAMESPACE}.svc.cluster.local"
                                     }
                                 ],
                                 "securityContext": {

--- a/openshift-examples/keycloak-https.json
+++ b/openshift-examples/keycloak-https.json
@@ -55,6 +55,12 @@
             "name": "HOSTNAME_HTTPS",
             "value": "",
             "required": false
+        },
+        {
+            "displayName": "Namespace used for DNS discovery",
+            "description": "This namespace is a part of DNS query sent to Kubernetes API. This query allows the DNS_PING protocol to extract cluster members. This parameter might be removed once https://issues.jboss.org/browse/JGRP-2292 is implemented.",
+            "name": "NAMESPACE",
+            "required": true
         }
     ],
     "objects": [
@@ -207,6 +213,14 @@
                                     {
                                         "name": "DB_VENDOR",
                                         "value": "${DB_VENDOR}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_DISCOVERY_PROTOCOL",
+                                        "value": "dns.DNS_PING"
+                                    },
+                                    {
+                                        "name": "JGROUPS_DISCOVERY_PROPERTIES",
+                                        "value": "${APPLICATION_NAME}.${NAMESPACE}.svc.cluster.local"
                                     }
                                 ],
                                 "securityContext": {

--- a/server/README.md
+++ b/server/README.md
@@ -141,17 +141,75 @@ found here:
 
 
 
-## Adding custom theme
+## Adding a custom theme
 
 To add a custom theme extend the Keycloak image add the theme to the `/opt/jboss/keycloak/themes` directory.
 
 
 
-## Adding custom provider
+## Adding a custom provider
 
 To add a custom provider extend the Keycloak image and add the provider to the `/opt/jboss/keycloak/standalone/deployments/`
 directory.
 
+
+## Clustering
+
+Replacing the default discovery protocols (`PING` for the UDP stack and `MPING` for the TCP one) can be achieved by defining
+two additional environment variables:
+
+- `JGROUPS_DISCOVERY_PROTOCOL` - name of the discovery protocol, e.g. DNS_PING
+- `JGROUPS_DISCOVERY_PROPERTIES` - an optional parameter with the discovery protocol properties in the following format:
+`PROP1=FOO,PROP2=BAR`
+
+The bootstrap script will detect the variables and adjust the `standalone-ha.xml` configuration based on them.
+
+### PING example
+
+The `PING` discovery protocol is used by default in `udp` stack (which is used by default in `standalone-ha.xml`).
+Since the Keycloak image runs in clustered mode by default, all you need to do is to run it:
+
+    docker run jboss/keycloak
+
+If you two instances of it locally, you will notice that they form a cluster.
+
+### OpenShift example with dns.DNS_PING
+
+Clustering for OpenShift can be achieved by using either `dns.DNS_PING` and a governing service or `kubernetes.KUBE_PING`.
+The latter requires `view` permissions which are not granted by default, so we suggest using `dns.DNS_PING`.
+
+#### Using the template
+
+The full example has been put into the `openshift-examples` directory. Just run one of the two templates. Here's an example:
+
+    oc new-app -p NAMESPACE=`oc project -q` -f keycloak-https.json
+
+#### What happen under the hood?
+
+Both OpenShift templates use `dns.DNS_PING` under the hood. Here's an equivalent docker-based command that OpenShift
+is invoking:
+
+    docker run \
+    -e JGROUPS_DISCOVERY_PROTOCOL=dns.DNS_PING -e \
+    JGROUPS_DISCOVERY_PROPERTIES=dns_query=keycloak.myproject.svc.cluster.local \
+    jboss/keycloak
+
+In this example the `dns.DNS_PING` that queries `A` records from the DNS Server with the following query
+`keycloak.myproject.svc.cluster.local`.
+
+### Adding custom discovery protocols
+
+The default mechanism for adding discovery protocols should cover most of the cases. However, sometimes
+you need to add more protocols at the same time, or adjust other protocols. In such cases you will need
+your own cli file placed in `/opt/jboss/tools/cli/jgroups/discovery`. The `JGROUPS_DISCOVERY_PROTOCOL` need to
+match your cli file, for example:
+
+    JGROUPS_DISCOVERY_PROTOCOL=custom_protocol
+    /opt/jboss/tools/cli/jgroups/discovery/custom_protocol.cli
+
+This can be easily achieved by extending the Keycloak image and adding just one file.
+
+Of course, we highly encourage you to contribute your custom scripts back to the community image!
 
 
 ## Misc

--- a/server/tools/cli/jgroups/discovery/default.cli
+++ b/server/tools/cli/jgroups/discovery/default.cli
@@ -1,0 +1,9 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=jgroups/stack=udp/protocol=PING:remove()
+/subsystem=jgroups/stack=udp/protocol=$keycloak_jgroups_discovery_protocol:add(add-index=0, properties=$keycloak_jgroups_discovery_protocol_properties)
+
+/subsystem=jgroups/stack=tcp/protocol=MPING:remove()
+/subsystem=jgroups/stack=tcp/protocol=$keycloak_jgroups_discovery_protocol:add(add-index=0, properties=$keycloak_jgroups_discovery_protocol_properties)
+run-batch
+stop-embedded-server

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -24,6 +24,27 @@ if [ "$KEYCLOAK_HOSTNAME" != "" ]; then
     fi
 fi
 
+########################
+# JGroups bind options #
+########################
+
+if [ -z "$BIND" ]; then
+    BIND=$(hostname -i)
+fi
+if [ -z "$BIND_OPTS" ]; then
+    BIND_OPTS="-Djboss.bind.address=$BIND -Djboss.bind.address.private=$BIND"
+fi
+SYS_PROPS+=" $BIND_OPTS"
+
+#################
+# Configuration #
+#################
+
+# If the "-c" parameter is not present, append the HA profile.
+if echo "$@" | egrep -v -- "-c "; then
+    SYS_PROPS+=" -c standalone-ha.xml"
+fi
+
 ############
 # DB setup #
 ############
@@ -103,6 +124,7 @@ if [ "$DB_VENDOR" != "h2" ]; then
 fi
 
 /opt/jboss/tools/x509.sh
+/opt/jboss/tools/jgroups.sh $JGROUPS_DISCOVERY_PROTOCOL $JGROUPS_DISCOVERY_PROPERTIES
 
 ##################
 # Start Keycloak #

--- a/server/tools/jgroups.sh
+++ b/server/tools/jgroups.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+JGROUPS_DISCOVERY_PROTOCOL=$1
+# This parameter must be in the following format: PROP1=FOO,PROP2=BAR
+JGROUPS_DISCOVERY_PROPERTIES=$2
+
+if [ -n "$JGROUPS_DISCOVERY_PROTOCOL" ]; then
+    JGROUPS_DISCOVERY_PROPERTIES_PARSED=`echo $JGROUPS_DISCOVERY_PROPERTIES | sed "s/=/=>/g"`
+    JGROUPS_DISCOVERY_PROPERTIES_PARSED="{$JGROUPS_DISCOVERY_PROPERTIES_PARSED}"
+    echo "Setting JGroups discovery to $JGROUPS_DISCOVERY_PROTOCOL with properties $JGROUPS_DISCOVERY_PROPERTIES_PARSED"
+    echo "set keycloak_jgroups_discovery_protocol=${JGROUPS_DISCOVERY_PROTOCOL}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set keycloak_jgroups_discovery_protocol_properties=${JGROUPS_DISCOVERY_PROPERTIES_PARSED}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    # If there's a specific CLI file for given protocol - execute it. If not, we should be good with the default one.
+    if [ -f "/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" ]; then
+       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" >& /dev/null
+    else
+       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/default.cli" >& /dev/null
+    fi
+fi


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-7582

This PR adds clustering support for the Keycloak Docker image. As the matter of fact, it makes allows to use any discovery protocol with custom configuration.

Here's how it works:
* The configuration scripts pick up `JGROUPS_DISCOVERY_PROTOCOL` and `JGROUPS_DISCOVERY_PROPERTIES` variables.
* In the next step, the main entry point script passes those two configuration variables to `jgroups.sh` script.
* The script adjusts the variables and invokes `cli/jgroups/discovery/default.cli` (or a cli file with an exact protocol name if it exists; but in most of the cases, the `default.cli` should be enough).
* The CLI script modifies `standalone-ha.xml`. It removed the default discovery protocol and replaces it with the one specified above.
* The final piece of the puzzle is adjusting JGroups bind options. By default they operate on the `private` interface. We need rewire it to the external, public port. By default we use `hostname -i` for that.

I also uploaded a test image, so that you can play with it. Just replace the `image` tag in the template with `slaskawi/keycloak-jgroups-discovery`.