### PR TITLE
Fixes KEYCLOAK-8459. Avoid crash when started with more than one network

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -40,7 +40,10 @@ if [ -z "$BIND" ]; then
     BIND=$(hostname -i)
 fi
 if [ -z "$BIND_OPTS" ]; then
-    BIND_OPTS="-Djboss.bind.address=$BIND -Djboss.bind.address.private=$BIND"
+    for BIND_IP in $BIND
+    do
+        BIND_OPTS+=" -Djboss.bind.address=$BIND_IP -Djboss.bind.address.private=$BIND_IP "
+    done
 fi
 SYS_PROPS+=" $BIND_OPTS"
 


### PR DESCRIPTION
When keycloak is started with several networks, `hostname -i` returns a space separated list of ip addresses. Unfortunately, `jboss.bind.address` and `jboss.bind.address.private` only accept a single ip.
This PR just ensure to loop over each ip to set BIND_OPTS appropriately.
