### PR TITLE
KEYCLOAK-10198 KEYCLOAK-10199: Allow JGroups transport stack configuration

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -213,7 +213,7 @@ two additional environment variables:
 - `JGROUPS_DISCOVERY_PROTOCOL` - name of the discovery protocol, e.g. DNS_PING
 - `JGROUPS_DISCOVERY_PROPERTIES` - an optional parameter with the discovery protocol properties in the following format:
 `PROP1=FOO,PROP2=BAR`
-- `JGROUPS_TRANSPORT_STACK` - an optional name of the transport stack to use `udp` or `tcp` are possible values. Default: `udp` 
+- `JGROUPS_TRANSPORT_STACK` - an optional name of the transport stack to use `udp` or `tcp` are possible values. Default: `tcp` 
 
 The bootstrap script will detect the variables and adjust the `standalone-ha.xml` configuration based on them.
 

--- a/server/README.md
+++ b/server/README.md
@@ -213,6 +213,7 @@ two additional environment variables:
 - `JGROUPS_DISCOVERY_PROTOCOL` - name of the discovery protocol, e.g. DNS_PING
 - `JGROUPS_DISCOVERY_PROPERTIES` - an optional parameter with the discovery protocol properties in the following format:
 `PROP1=FOO,PROP2=BAR`
+- `JGROUPS_TRANSPORT_STACK` - an optional name of the transport stack to use `udp` or `tcp` are possible values. Default: `udp` 
 
 The bootstrap script will detect the variables and adjust the `standalone-ha.xml` configuration based on them.
 

--- a/server/tools/cli/jgroups/discovery/default.cli
+++ b/server/tools/cli/jgroups/discovery/default.cli
@@ -5,5 +5,7 @@ batch
 
 /subsystem=jgroups/stack=tcp/protocol=MPING:remove()
 /subsystem=jgroups/stack=tcp/protocol=$keycloak_jgroups_discovery_protocol:add(add-index=0, properties=$keycloak_jgroups_discovery_protocol_properties)
+
+/subsystem=jgroups/channel=ee:write-attribute(name="stack", value=$keycloak_jgroups_transport_stack)
 run-batch
 stop-embedded-server

--- a/server/tools/jgroups.sh
+++ b/server/tools/jgroups.sh
@@ -10,7 +10,7 @@ if [ -n "$JGROUPS_DISCOVERY_PROTOCOL" ]; then
     echo "Setting JGroups discovery to $JGROUPS_DISCOVERY_PROTOCOL with properties $JGROUPS_DISCOVERY_PROPERTIES_PARSED"
     echo "set keycloak_jgroups_discovery_protocol=${JGROUPS_DISCOVERY_PROTOCOL}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_jgroups_discovery_protocol_properties=${JGROUPS_DISCOVERY_PROPERTIES_PARSED}" >> "$JBOSS_HOME/bin/.jbossclirc"
-    echo "set keycloak_jgroups_transport_stack=${JGROUPS_TRANSPORT_STACK:-udp}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set keycloak_jgroups_transport_stack=${JGROUPS_TRANSPORT_STACK:-tcp}" >> "$JBOSS_HOME/bin/.jbossclirc"
     # If there's a specific CLI file for given protocol - execute it. If not, we should be good with the default one.
     if [ -f "/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" ]; then
        $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" >& /dev/null

--- a/server/tools/jgroups.sh
+++ b/server/tools/jgroups.sh
@@ -10,6 +10,7 @@ if [ -n "$JGROUPS_DISCOVERY_PROTOCOL" ]; then
     echo "Setting JGroups discovery to $JGROUPS_DISCOVERY_PROTOCOL with properties $JGROUPS_DISCOVERY_PROPERTIES_PARSED"
     echo "set keycloak_jgroups_discovery_protocol=${JGROUPS_DISCOVERY_PROTOCOL}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_jgroups_discovery_protocol_properties=${JGROUPS_DISCOVERY_PROPERTIES_PARSED}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set keycloak_jgroups_transport_stack=${JGROUPS_TRANSPORT_STACK:-udp}" >> "$JBOSS_HOME/bin/.jbossclirc"
     # If there's a specific CLI file for given protocol - execute it. If not, we should be good with the default one.
     if [ -f "/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" ]; then
        $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" >& /dev/null


### PR DESCRIPTION
We have a clustered keycloak deployment on Google Kubernetes Engine. Since Google Cloud Platform does not support UDP multicast we use TCP.

The configuration option introduced in this PR greatly simplifies the configuration. The JGroups transport stack can be changed using the environment variable JGROUPS_TRANSPORT_STACK