### PR TITLE
Fixing truststore import message

### DIFF
--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -82,7 +82,7 @@ function autogenerate_keystores() {
       -destkeystore "${JKS_TRUSTSTORE_PATH}" \
       -srcstoretype jks -deststoretype jks \
       -storepass "${PASSWORD}" -srcstorepass "changeit" >& /dev/null
-      if [ "$?" -ne "0" ]; then
+      if [ "$?" -eq "0" ]; then
         echo "Successfully imported certificates from system's Java CA certificate bundle into Keycloak truststore at: ${JKS_TRUSTSTORE_PATH}"
       else
         echo "Failed to import certificates from system's Java CA certificate bundle into Keycloak truststore!"


### PR DESCRIPTION
I was using the `X509_CA_BUNDLE` feature when I noticed in the logs that it `"Failed to import certificates from system's Java CA certificate bundle into Keycloak truststore!"`.

I pulled the container down and built the truststore manually like the script does, and it succeeded. I checked the return code and it was 0, so I believe this is backwards.