### PR TITLE
Allow Switching the discovery Stack to TCP

### DIFF
--- a/server/tools/cli/jgroups/discovery/default.cli
+++ b/server/tools/cli/jgroups/discovery/default.cli
@@ -1,5 +1,8 @@
 embed-server --server-config=standalone-ha.xml --std-out=echo
 batch
+
+/subsystem=jgroups/channel=ee:write-attribute(name=stack,value=${env.JGROUPS_DISCOVERY_STACK:udp})
+
 /subsystem=jgroups/stack=udp/protocol=PING:remove()
 /subsystem=jgroups/stack=udp/protocol=$keycloak_jgroups_discovery_protocol:add(add-index=0, properties=$keycloak_jgroups_discovery_protocol_properties)
 


### PR DESCRIPTION
On Openshift we need "multicast" for the default of dns.DNS_PING to
work with UDP . This may not be available in older clusters (I think a
3.6 feature) and also it may be a security problem in larger, shared
projects.