### PR TITLE
KEYCLOAK-9881: add postgres connection fail-over url

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -69,7 +69,10 @@ If the DB can't be detected it will default to the embedded H2 database.
 
 Generic variable names can be used to configure any Database type, defaults may vary depending on the Database.
 
-- `DB_ADDR`: Specify hostname of the database (optional)
+- `DB_ADDR`: Specify hostname of the database (optional). For postgres only, you can provide a list of hostnames separated by
+comma to failover alternative host. The hostname can be the host only or pair of host and port, as example host1,host2 or 
+host1:5421,host2:5436 or host1,host2:5000. And keycloak will append DB_PORT (if specify) to the hosts without port, 
+otherwise it will append the default port 5432, again to the address without port only.
 - `DB_PORT`: Specify port of the database (optional, default is DB vendor default port)
 - `DB_DATABASE`: Specify name of the database to use (optional, default is `keycloak`).
 - `DB_USER`: Specify user to use to authenticate to the database (optional, default is `keycloak`).

--- a/server/tools/cli/databases/postgres/change-database.cli
+++ b/server/tools/cli/databases/postgres/change-database.cli
@@ -1,5 +1,5 @@
 /subsystem=datasources/data-source=KeycloakDS: remove()
-/subsystem=datasources/data-source=KeycloakDS: add(jndi-name=java:jboss/datasources/KeycloakDS,enabled=true,use-java-context=true,use-ccm=true, connection-url=jdbc:postgresql://${env.DB_ADDR:postgres}:${env.DB_PORT:5432}/${env.DB_DATABASE:keycloak}${env.JDBC_PARAMS:}, driver-name=postgresql)
+/subsystem=datasources/data-source=KeycloakDS: add(jndi-name=java:jboss/datasources/KeycloakDS,enabled=true,use-java-context=true,use-ccm=true, connection-url=jdbc:postgresql://${env.DB_ADDR:postgres}/${env.DB_DATABASE:keycloak}${env.JDBC_PARAMS:}, driver-name=postgresql)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=user-name, value=${env.DB_USER:keycloak})
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=password, value=${env.DB_PASSWORD:password})
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=check-valid-connection-sql, value="SELECT 1")

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -93,7 +93,10 @@ fi
 # Set DB name
 case "$DB_VENDOR" in
     postgres)
-        DB_NAME="PostgreSQL";;
+        DB_NAME="PostgreSQL"
+        if [ -z "$BD_PORT" ] ; then BD_PORT="5432" ; fi
+        append_port_db_addr
+        ;;
     mysql)
         DB_NAME="MySQL";;
     mariadb)
@@ -120,6 +123,22 @@ function set_legacy_vars() {
   done
 }
 set_legacy_vars `echo $DB_VENDOR | tr a-z A-Z`
+
+# if the DB_VENDOR is postgres then append port to the DB_ADDR
+function append_port_db_addr() {
+  local db_host_regex='^[a-zA-Z0-9]([a-zA-Z0-9]|-|.)*:[0-9]{4,5}$'
+  IFS=',' read -ra addresses <<< "$DB_ADDR"
+  DB_ADDR=""
+  for i in "${addresses[@]}"; do
+    if [[ $i =~ $db_host_regex ]]; then
+        DB_ADDR+=$i;
+     else
+        DB_ADDR+="${i}:${DB_PORT}";
+     fi
+        DB_ADDR+=","
+  done
+  DB_ADDR=$(echo $DB_ADDR | sed 's/.$//') # remove the last comma
+}
 
 # Configure DB
 


### PR DESCRIPTION
jdbc allow connection fail-over for postgres. Please refer to https://jdbc.postgresql.org/documentation/head/connect.html
