### PR TITLE
Support a docker-entrypoint.d directory

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -166,12 +166,16 @@ directory.
 
 ## Running custom scripts on startup
 
-To run a custom `.cli` script on container startup extend the Keycloak image and add the `.cli` file to the
-`/opt/jboss/keycloak/tools/docker-entrypoint.d` directory (create it if necessary).
+To run custom scripts on container startup either extend the Keycloak image or use a volume, then add your script to
+the `/docker-entrypoint.d` directory.
 
-It is also possible to add executable scripts (`chmod +x`) to this directory.
+Two types of scripts are supported:
 
-Files are ran in alphabetical order.
+* WildFly `.cli` [scripts](https://docs.jboss.org/author/display/WFLY/Command+Line+Interface)
+
+* Any executable (`chmod +x`) script
+
+Scripts are ran in alphabetical order.
 
 ## Clustering
 

--- a/server/README.md
+++ b/server/README.md
@@ -164,6 +164,14 @@ To set the welcome theme, use the following environment value :
 To add a custom provider extend the Keycloak image and add the provider to the `/opt/jboss/keycloak/standalone/deployments/`
 directory.
 
+## Running custom scripts on startup
+
+To run a custom `.cli` script on container startup extend the Keycloak image and add the `.cli` file to the
+`/opt/jboss/keycloak/tools/docker-entrypoint.d` directory (create it if necessary).
+
+It is also possible to add executable scripts (`chmod +x`) to this directory.
+
+Files are ran in alphabetical order.
 
 ## Clustering
 

--- a/server/README.md
+++ b/server/README.md
@@ -166,8 +166,9 @@ directory.
 
 ## Running custom scripts on startup
 
-To run custom scripts on container startup either extend the Keycloak image or use a volume, then add your script to
-the `/docker-entrypoint.d` directory.
+**Warning**: Custom scripts have no guarantees. The directory layout within the image may change at any time.
+
+To run custom scripts on container startup place a file in the `/opt/jboss/startup-scripts` directory.
 
 Two types of scripts are supported:
 
@@ -176,6 +177,23 @@ Two types of scripts are supported:
 * Any executable (`chmod +x`) script
 
 Scripts are ran in alphabetical order.
+
+### Adding custom script using Dockerfile
+
+A custom script can be added by creating your own `Dockerfile`:
+
+```
+FROM keycloak
+COPY custom-scripts/ /opt/jboss/startup-scripts/
+```
+
+### Adding custom script using volumes
+
+A single custom script can be added as a volume: `docker run -v /some/dir/my-script.cli:/opt/jboss/startup-scripts/my-script.cli`
+Or you can volume the entire directory to supply a directory of scripts.
+
+Note that when combining the approach of extending the image and `volume`ing the entire directory, the volume will override
+all scripts shipped in the image.
 
 ## Clustering
 

--- a/server/tools/autorun.sh
+++ b/server/tools/autorun.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 cd /opt/jboss/keycloak
 
-ENTRYPOINT_DIR=/docker-entrypoint.d
+ENTRYPOINT_DIR=/opt/jboss/startup-scripts
 
 if [[ -d "$ENTRYPOINT_DIR" ]]; then
   # First run cli autoruns

--- a/server/tools/autorun.sh
+++ b/server/tools/autorun.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cd /opt/jboss/keycloak
+
+ENTRYPOINT_DIR=/opt/jboss/tools/docker-entrypoint.d
+
+if [[ -d "$ENTRYPOINT_DIR" ]]; then
+  # First run cli autoruns
+  for f in "$ENTRYPOINT_DIR"/*; do
+    if [[ "$f" == *.cli ]]; then
+      echo "Executing cli script: $f"
+      bin/jboss-cli.sh --file="$f"
+    elif [[ -x "$f" ]]; then
+      echo "Executing: $f"
+      "$f"
+    else
+      echo "Ignoring file in docker-entrypoint.d directory (not *.cli or executable): $f"
+    fi
+  done
+fi

--- a/server/tools/autorun.sh
+++ b/server/tools/autorun.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 cd /opt/jboss/keycloak
 
 ENTRYPOINT_DIR=/docker-entrypoint.d

--- a/server/tools/autorun.sh
+++ b/server/tools/autorun.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd /opt/jboss/keycloak
 
-ENTRYPOINT_DIR=/opt/jboss/tools/docker-entrypoint.d
+ENTRYPOINT_DIR=/docker-entrypoint.d
 
 if [[ -d "$ENTRYPOINT_DIR" ]]; then
   # First run cli autoruns

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -136,6 +136,7 @@ fi
 
 /opt/jboss/tools/x509.sh
 /opt/jboss/tools/jgroups.sh $JGROUPS_DISCOVERY_PROTOCOL $JGROUPS_DISCOVERY_PROPERTIES
+/opt/jboss/tools/autorun.sh
 
 ##################
 # Start Keycloak #


### PR DESCRIPTION
This change will allow extending images to simply drop files in `/opt/jboss/keycloak/tools/docker-entrypoint.d` to have them ran on container startup. Special support for `.cli` files is provided.

This is useful for, in our case, simple tweaks to the `standalone.xml`.