### PR TITLE
Fix error message path in autorun

### DIFF
--- a/server/tools/autorun.sh
+++ b/server/tools/autorun.sh
@@ -13,7 +13,7 @@ if [[ -d "$ENTRYPOINT_DIR" ]]; then
       echo "Executing: $f"
       "$f"
     else
-      echo "Ignoring file in docker-entrypoint.d directory (not *.cli or executable): $f"
+      echo "Ignoring file in $ENTRYPOINT_DIR (not *.cli or executable): $f"
     fi
   done
 fi


### PR DESCRIPTION
In #176 this directory was introduced, then renamed. This PR will also update the error message to display the correct directory name.