### PR TITLE
KEYCLOAK-9715 add KEYCLOAK_DEFAULT_THEME to set global default theme

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -158,6 +158,9 @@ To set the welcome theme, use the following environment value :
 
 * `KEYCLOAK_WELCOME_THEME`: Specify the theme to use for welcome page (must be non empty and must match an existing theme name)
 
+To set your custom theme as the default global theme, use the following environment value :
+* `KEYCLOAK_DEFAULT_THEME`: Specify the theme to use as the default global theme (must match an existing theme name, if empty will use keycloak)
+
 
 ## Adding a custom provider
 

--- a/server/tools/cli/theme.cli
+++ b/server/tools/cli/theme.cli
@@ -1,1 +1,2 @@
 /subsystem=keycloak-server/theme=defaults:write-attribute(name=welcomeTheme,value=${env.KEYCLOAK_WELCOME_THEME:keycloak})
+/subsystem=keycloak-server/theme=defaults:write-attribute(name=default,value=${env.KEYCLOAK_DEFAULT_THEME:keycloak})


### PR DESCRIPTION
Providing the ability to set the global default theme within a container image by setting an environment variable KEYCLOAK_DEFAULT_THEME with the name of the custom theme.

If environment variable is not set, theme will default to keycloak. Same behaviour as the KEYCLOAK_WELCOME_THEME.

Changes tested by :
1. extending container image with custom theme and setting environment variable. Launch container and verify custom theme is set. 
2. executing base container to ensure default is still keycloak theme.
