### PR TITLE
KEYCLOAK-9787: Support for file-based provisioning of Keycloak admin username and password

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -35,7 +35,11 @@ Then restarting the container:
 
     docker restart <CONTAINER>
 
+### Providing the username and password via files
 
+By appending `_FILE` to the two environment variables used above (`KEYCLOAK_USER_FILE` and `KEYCLOAK_PASSWORD_FILE`),
+the information can be provided via files instead of plain environment variable values.
+The configuration and secret support in Docker Swarm is a perfect match for this use case. 
 
 ## Importing a realm
 
@@ -73,7 +77,9 @@ Generic variable names can be used to configure any Database type, defaults may 
 - `DB_PORT`: Specify port of the database (optional, default is DB vendor default port)
 - `DB_DATABASE`: Specify name of the database to use (optional, default is `keycloak`).
 - `DB_USER`: Specify user to use to authenticate to the database (optional, default is `keycloak`).
+- `DB_USER_FILE`: Specify user to authenticate to the database via file input (alternative to `DB_USER`).
 - `DB_PASSWORD`: Specify user's password to use to authenticate to the database (optional, default is `password`).
+- `DB_PASSWORD_FILE`: Specify user's password to use to authenticate to the database via file input (alternative to `DB_PASSWORD`).
 
 ### MySQL Example
 

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -1,8 +1,33 @@
 #!/bin/bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 ##################
 # Add admin user #
 ##################
+
+file_env 'KEYCLOAK_USER'
+file_env 'KEYCLOAK_PASSWORD'
 
 if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     /opt/jboss/keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
@@ -59,6 +84,9 @@ fi
 ############
 # DB setup #
 ############
+
+file_env 'DB_USER'
+file_env 'DB_PASSWORD'
 
 # Lower case DB_VENDOR
 DB_VENDOR=`echo $DB_VENDOR | tr A-Z a-z`


### PR DESCRIPTION
Adds a ```file_env``` function and support for using the environment variables ```KEYCLOAK_USER_FILE``` and ```KEYCLOAK_PASSWORD_FILE``` to the Dockerfile.
Also adds a comment to each of the Docker compose example files to use these if Docker Swarm secrets support is available.
