### PR TITLE
KEYCLOAK-9767 Bind to proper interface

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -62,7 +62,7 @@ fi
 ########################
 
 if [ -z "$BIND" ]; then
-    BIND=$(hostname -i)
+    BIND=$(hostname --all-ip-addresses)
 fi
 if [ -z "$BIND_OPTS" ]; then
     for BIND_IP in $BIND


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-9767

This commit allows running the Keycloak image with Podman. The root cause, why it didn't work was that we were binding to a wrong interface - `fe80::5003:8eff:fefa:3e53%tap0`. I corrected this with this PR.

You may test this using `podman run slaskawi/keycloak-tmp`.

@Nowheresly - This PR may affect you as you worked previously on https://github.com/jboss-dockerfiles/keycloak/pull/156. Could you please verify if it works for you?

@stianst - Could you please test it with your environment? for a short test, please use `podman run slaskawi/keycloak-tmp`. For a longer one, you'd need to rebuild the image.

 