### PR TITLE
KEYCLOAK-10189 Possibility to use Gitlab for build keycloak sources

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,6 +12,7 @@ ENV LANG en_US.UTF-8
 
 ARG GIT_REPO
 ARG GIT_BRANCH
+ARG GIT_HOST
 ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
 
 USER root

--- a/server/README.md
+++ b/server/README.md
@@ -335,6 +335,12 @@ It is possible to build Keycloak from a GitHub repository instead of downloading
 
 This will clone the repository then build Keycloak from source. If you don't include GIT_BRANCH it will use the `master` branch.
 
+You can also use another solution of repository like Gitlab using GIT_HOST option.
+
+    docker build --build-arg GIT_HOST=https://oauth2:[token]@gitlab.test.fr/gitlab GIT_REPO=keycloak/keycloak --build-arg GIT_BRANCH=master .
+
+A token must been create on your gitlab account to avoid the user/pass authentication.
+
 #### Download Keycloak from an alternative location
 
 It is possible to download the Keycloak distribution from an alternative location. This can for example be useful if you want to build a Docker image from Keycloak built locally. For example:

--- a/server/tools/build-keycloak.sh
+++ b/server/tools/build-keycloak.sh
@@ -9,6 +9,11 @@ if [ "$GIT_REPO" != "" ]; then
         GIT_BRANCH="master"
     fi
 
+if [ "$GIT_HOST" == "" ]; then
+    GIT_HOST="https://github.com"
+fi
+
+
     # Install Maven
     cd /opt/jboss 
     curl -s https://apache.uib.no/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz | tar xz
@@ -16,13 +21,13 @@ if [ "$GIT_REPO" != "" ]; then
     export M2_HOME=/opt/jboss/maven
 
     # Clone repository
-    git clone --depth 1 https://github.com/$GIT_REPO.git -b $GIT_BRANCH /opt/jboss/keycloak-source
+    git clone --depth 1 $GIT_HOST/$GIT_REPO.git -b $GIT_BRANCH /opt/jboss/keycloak-source
 
     # Build
     cd /opt/jboss/keycloak-source
 
     MASTER_HEAD=`git log -n1 --format="%H"`
-    echo "Keycloak from [build]: $GIT_REPO/$GIT_BRANCH/commit/$MASTER_HEAD"
+    echo "Keycloak from [build]: $GIT_HOST/$GIT_REPO/$GIT_BRANCH/commit/$MASTER_HEAD"
 
     $M2_HOME/bin/mvn -Pdistribution -pl distribution/server-dist -am -Dmaven.test.skip clean install
     


### PR DESCRIPTION
I add the possibility to use for exemple Gitlab repo when you want to build a new keycloak image from a non official repository.