### PR TITLE
KEYCLOAK-10285: Fix Docker hub links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Keycloak is an Open Source Identity and Access Management solution for modern Ap
 
 This repository contains Docker images related to Keycloak.
 
-- [keycloak](https://cloud.docker.com/u/jboss/repository/docker/jboss/keycloak) Keycloak server
-* [gatekeeper](https://cloud.docker.com/u/keycloak/repository/docker/keycloak/keycloak-gatekeeper)
-- [keycloak-adapter-wildfly](https://cloud.docker.com/u/jboss/repository/docker/jboss/keycloak-adapter-wildfly) WildFly including Keycloak adapter
+- [keycloak](https://hub.docker.com/r/jboss/keycloak) Keycloak server
+* [gatekeeper](https://hub.docker.com/r/keycloak/keycloak-gatekeeper) Keycloak gatekeeper
+- [keycloak-adapter-wildfly](https://hub.docker.com/r/jboss/keycloak-adapter-wildfly) WildFly including Keycloak adapter
 
 
 ## Help and Documentation


### PR DESCRIPTION
Issue: [KEYCLOAK-10285](https://issues.jboss.org/browse/KEYCLOAK-10285)

Fix the url link in the `README.md` file to use the updated versions of the Docker Hub urls.

## Example: 
#### before:
`https://cloud.docker.com/u/jboss/repository/docker/jboss/keycloak`
#### after:
`https://hub.docker.com/r/jboss/keycloak`