### PR TITLE
KEYCLOAK-10652 Truststore optimizations

### DIFF
--- a/openshift-examples/keycloak-https-mutual-tls.json
+++ b/openshift-examples/keycloak-https-mutual-tls.json
@@ -236,7 +236,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_DISCOVERY_PROTOCOL",

--- a/server/README.md
+++ b/server/README.md
@@ -416,8 +416,7 @@ Keycloak image allows you to specify both a private key and a certificate for se
 
 Those files need to be mounted in `/etc/x509/https` directory. The image will automatically convert them into a Java keystore and reconfigure Wildfly to use it.
 
-It is also possible to provide an additional CA bundle and setup Mutual TLS this way. In that case, you need to mount an additional volume to the image
-containing a `crt` file and point `X509_CA_BUNDLE` environmental variable to that file.
+It is also possible to provide an additional CA bundle and setup Mutual TLS this way. In that case, you need to mount an additional volume (or multiple volumes) to the image. These volumes should contain all necessary `crt` files. The final step is to configure the `X509_CA_BUNDLE` environment variable to contain a list of the locations of the various CA certificate bundle files specified before, separated by space (` `). In case of an OpenShift environment, that could be `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
 
 NOTE: See `openshift-examples` directory for an out of the box setup for OpenShift.
 

--- a/server/tools/cli/x509-truststore.cli
+++ b/server/tools/cli/x509-truststore.cli
@@ -12,4 +12,14 @@ else
 	/subsystem=elytron/server-ssl-context=kcSSLContext:write-attribute(name=trust-manager, value=kcTrustManager)
     /subsystem=elytron/server-ssl-context=kcSSLContext:write-attribute(name=want-client-auth, value=true)
 end-if
+
+if (outcome != success) of /subsystem=keycloak-server/spi=truststore:read-resource
+    /subsystem=keycloak-server/spi=truststore/:add
+end-if
+/subsystem=keycloak-server/spi=truststore/provider=file/:add(enabled=true,properties={ \
+    file => $keycloak_tls_truststore_file, \
+    password => $keycloak_tls_truststore_password, \
+    hostname-verification-policy => "WILDCARD", \
+disabled => "false"})
+
 stop-embedded-server

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -60,10 +60,14 @@ function autogenerate_keystores() {
   local JKS_TRUSTSTORE_FILE="truststore.jks"
   local JKS_TRUSTSTORE_PATH="${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}"
   local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+  local TEMPORARY_CERTIFICATE="temporary_ca.crt"
   if [ -n "${X509_CA_BUNDLE}" ]; then
     pushd /tmp >& /dev/null
     echo "Creating Keycloak truststore.."
-    csplit -s -z -f crt- "${X509_CA_BUNDLE}" "${X509_CRT_DELIMITER}" '{*}'
+    # We use cat here, so that users could specify multiple CA Bundles using space or even wildcard:
+    # X509_CA_BUNDLE=/var/run/secrets/kubernetes.io/serviceaccount/*.crt
+    cat "${X509_CA_BUNDLE}" > ${TEMPORARY_CERTIFICATE}
+    csplit -s -z -f crt- "${TEMPORARY_CERTIFICATE}" "${X509_CRT_DELIMITER}" '{*}'
     for CERT_FILE in crt-*; do
       keytool -import -noprompt -keystore "${JKS_TRUSTSTORE_PATH}" -file "${CERT_FILE}" \
       -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10652

This Pull Request allows adding multiple CA Bundles into `X509_CA_BUNDLE` and imports generated trust store into Truststore SPI. Here's an example:

```bash
X509_CA_BUNDLE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```

When running in Kubernetes with the example above, Keycloak will automatically be able to call other services deployed in OpenShift (using `service-ca.crt`) as we as the Kubernetes API server (using `ca.crt`).