### PR TITLE
KEYCLOAK-10789 Add optional unparsed JGROUPS_DISCOVERY_PROPERTIES_DIRECT

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -271,12 +271,16 @@ all scripts shipped in the image.
 ## Clustering
 
 Replacing the default discovery protocols (`PING` for the UDP stack and `MPING` for the TCP one) can be achieved by defining
-two additional environment variables:
+some additional environment variables:
 
 - `JGROUPS_DISCOVERY_PROTOCOL` - name of the discovery protocol, e.g. DNS_PING
 - `JGROUPS_DISCOVERY_PROPERTIES` - an optional parameter with the discovery protocol properties in the following format:
 `PROP1=FOO,PROP2=BAR`
+- `JGROUPS_DISCOVERY_PROPERTIES_DIRECT` - an optional parameter with the discovery protocol properties in jboss CLI format:
+`{PROP1=>FOO,PROP2=>BAR}`
 - `JGROUPS_TRANSPORT_STACK` - an optional name of the transport stack to use `udp` or `tcp` are possible values. Default: `tcp` 
+
+**Warning**: It's an error to set both JGROUPS_DISCOVERY_PROPERTIES and JGROUPS_DISCOVERY_PROPERTIES_DIRECT. No more than one of them may be set.
 
 The bootstrap script will detect the variables and adjust the `standalone-ha.xml` configuration based on them.
 

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -173,7 +173,7 @@ if [ "$DB_VENDOR" != "h2" ]; then
 fi
 
 /opt/jboss/tools/x509.sh
-/opt/jboss/tools/jgroups.sh $JGROUPS_DISCOVERY_PROTOCOL $JGROUPS_DISCOVERY_PROPERTIES
+/opt/jboss/tools/jgroups.sh
 /opt/jboss/tools/autorun.sh
 
 ##################

--- a/server/tools/jgroups.sh
+++ b/server/tools/jgroups.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 
-JGROUPS_DISCOVERY_PROTOCOL=$1
-# This parameter must be in the following format: PROP1=FOO,PROP2=BAR
-JGROUPS_DISCOVERY_PROPERTIES=$2
+# If JGROUPS_DISCOVERY_PROPERTIES is set, it must be in the following format: PROP1=FOO,PROP2=BAR
+# If JGROUPS_DISCOVERY_PROPERTIES_DIRECT is set, it must be in the following format: {PROP1=>FOO,PROP2=>BAR}
+# It's a configuration error to set both of these variables
 
 if [ -n "$JGROUPS_DISCOVERY_PROTOCOL" ]; then
-    JGROUPS_DISCOVERY_PROPERTIES_PARSED=`echo $JGROUPS_DISCOVERY_PROPERTIES | sed "s/=/=>/g"`
-    JGROUPS_DISCOVERY_PROPERTIES_PARSED="{$JGROUPS_DISCOVERY_PROPERTIES_PARSED}"
+    if [ -n "$JGROUPS_DISCOVERY_PROPERTIES" ] && [ -n "$JGROUPS_DISCOVERY_PROPERTIES_DIRECT" ]; then
+       echo >&2 "error: both JGROUPS_DISCOVERY_PROPERTIES and JGROUPS_DISCOVERY_PROPERTIES_DIRECT are set (but are exclusive)"
+       exit 1
+    fi
+
+    if [ -n "$JGROUPS_DISCOVERY_PROPERTIES_DIRECT" ]; then
+       JGROUPS_DISCOVERY_PROPERTIES_PARSED="$JGROUPS_DISCOVERY_PROPERTIES_DIRECT"
+    else
+       JGROUPS_DISCOVERY_PROPERTIES_PARSED=`echo $JGROUPS_DISCOVERY_PROPERTIES | sed "s/=/=>/g"`
+       JGROUPS_DISCOVERY_PROPERTIES_PARSED="{$JGROUPS_DISCOVERY_PROPERTIES_PARSED}"
+    fi
+
     echo "Setting JGroups discovery to $JGROUPS_DISCOVERY_PROTOCOL with properties $JGROUPS_DISCOVERY_PROPERTIES_PARSED"
     echo "set keycloak_jgroups_discovery_protocol=${JGROUPS_DISCOVERY_PROTOCOL}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_jgroups_discovery_protocol_properties=${JGROUPS_DISCOVERY_PROPERTIES_PARSED}" >> "$JBOSS_HOME/bin/.jbossclirc"


### PR DESCRIPTION
The parsing step of JGROUPS_DISCOVERY_PROPERTIES in jgroups.sh makes
it impossible to correctly specify properties whose value includes an
`=` character. Some discovery protocols, such as KUBE_PING, require
properties that have an `=` in their value, i.e., `{labels=>app=keycloak}`
