### PR TITLE
Exposed management port

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -71,7 +71,7 @@ fi
 if [ -z "$BIND_OPTS" ]; then
     for BIND_IP in $BIND
     do
-        BIND_OPTS+=" -Djboss.bind.address=$BIND_IP -Djboss.bind.address.private=$BIND_IP "
+        BIND_OPTS+=" -Djboss.bind.address=$BIND_IP -Djboss.bind.address.private=$BIND_IP -Djboss.bind.address.management=$BIND_IP "
     done
 fi
 SYS_PROPS+=" $BIND_OPTS"


### PR DESCRIPTION
Since Keycloak 6.0.1 has healthcheck and prometheus metrics on management endpoint, I've set the same value for jboss.bind.address.management property as for other interfaces
